### PR TITLE
Fixed a typo in the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You'll need the following:
 
 CACE can be installed directly from PyPI:
 
-	$ python3 -m pip install --upgrade openlane
+	$ python3 -m pip install --upgrade cace
 Prerequisite design tools:
 
 - xschem:  [https://github.com/stefanschippers/xschem](https://github.com/stefanschippers/xschem)


### PR DESCRIPTION
Fixed a typo in the README file where the instructions for pip install were for installing openlane, not cace.