### PR TITLE
Force ngspice exit on error

### DIFF
--- a/cace/common/cace_simulate.py
+++ b/cace/common/cace_simulate.py
@@ -136,13 +136,18 @@ def cace_simulate(param, testbench, pdk, paths, runtime_options):
         print('Current working directory is: ' + os.getcwd())
 
         with subprocess.Popen([simulator, *simargs, filename],
-			stdout=subprocess.PIPE, bufsize=1,
+			stdout=subprocess.PIPE,
+			stderr=subprocess.STDOUT,
+			bufsize=1,
 			start_new_session=True,
 			universal_newlines=True) as spiceproc:
             pgroup = os.getpgid(spiceproc.pid)
             for line in spiceproc.stdout:
                 print(line, end='')
                 sys.stdout.flush()
+                if 'Simulation interrupted' in line:
+                    print('ngspice encountered an error. . . ending.')
+                    spiceproc.kill()
 
         spiceproc.stdout.close()
         return_code = spiceproc.wait()


### PR DESCRIPTION
Implemented code that catches ngspice dropping back to the interpreter after encountering a parse error in the input.  This prevents the severe problem of having all the simulations "lock up" and fail to respond because they are all waiting for interpreter input that will not be coming.  Unfortunately the ngspice setting "strict_errorhandling" does not work for parse errors, and until that is fixed, this somewhat hack solution is a valid workaround.