### PR TITLE
Fixed adding results after netlist type is changed.

### DIFF
--- a/cace/cace_gui.py
+++ b/cace/cace_gui.py
@@ -308,7 +308,7 @@ class CACECharacterize(ttk.Frame):
 
         self.origin.set('Schematic Capture')
         self.toppane.title2_frame.origin_select = ttk.OptionMenu(self.toppane.title2_frame,
-		self.origin, 'Schematic Capture', 'Schematic Capture', 'Layout Extracted', 'R-C Extracted',
+		self.origin, 'Schematic Capture', 'Schematic Capture', 'Layout Extracted', 'C Extracted', 'R-C Extracted',
 		style='blue.TMenubutton', command=self.swap_results)
         self.toppane.title2_frame.origin_select.grid(column=5, row=0, ipadx = 5)
 
@@ -738,8 +738,16 @@ class CACECharacterize(ttk.Frame):
 
         if self.origin.get() == 'Schematic Capture':
             runtime_options['netlist_source'] = 'schematic'
-        else:
+        elif self.origin.get() == 'Layout Extracted':
             runtime_options['netlist_source'] = 'layout'
+        elif self.origin.get() == 'C Extracted':
+            runtime_options['netlist_source'] = 'pex'
+        elif self.origin.get() == 'R-C Extracted':
+            runtime_options['netlist_source'] = 'rcx'
+        else:
+            print('Unhandled netlist source ' + self.origin.get())
+            print('Reverting to schematic.')
+            runtime_options['netlist_source'] = 'schematic'
 
         runtime_options['force'] = self.settings.get_force()
         runtime_options['keep'] = self.settings.get_keep()
@@ -1137,6 +1145,8 @@ class CACECharacterize(ttk.Frame):
                 print('Error:  Cannot find directory spice/ in path ' + dspath)
 
         if self.origin.get() == 'Layout Extracted':
+            spifile = dsdir + '/layout/' + dsroot + '.spice'
+        if self.origin.get() == 'C Extracted':
             spifile = dsdir + '/pex/' + dsroot + '.spice'
         elif self.origin.get() == 'R-C Extracted':
             spifile = dsdir + '/rcx/' + dsroot + '.spice'
@@ -1397,14 +1407,19 @@ class CACECharacterize(ttk.Frame):
                     if not isinstance(resultlist, list):
                         resultlist = [resultlist]
 
-                    if self.origin.get() == 'Layout Extracted':
-                        for resultdict in resultlist:
-                            if resultdict['name'] == 'layout':
-                                valid = True
-                                break
-                    elif self.origin.get() == 'R-C Extracted':
+                    if self.origin.get() == 'R-C Extracted':
                         for resultdict in resultlist:
                             if resultdict['name'] == 'rcx':
+                                valid = True
+                                break
+                    elif self.origin.get() == 'C Extracted':
+                        for resultdict in resultlist:
+                            if resultdict['name'] == 'pex':
+                                valid = True
+                                break
+                    elif self.origin.get() == 'Layout Extracted':
+                        for resultdict in resultlist:
+                            if resultdict['name'] == 'layout':
                                 valid = True
                                 break
                     else:	# Schematic capture

--- a/cace/common/cace_collate.py
+++ b/cace/common/cace_collate.py
@@ -214,7 +214,8 @@ def find_limits(spectype, spec, results, units, debug=False):
             # value in the display.
             if value < targval - 0.0005:
                 score = 'fail'
-                print('fail: target = ' + str(score) + '\n')
+                if debug:
+                    print('fail: target = ' + str(score) + '\n')
             elif math.isnan(value):
                 score = 'fail'
 
@@ -230,7 +231,8 @@ def find_limits(spectype, spec, results, units, debug=False):
             # value in the display.
             if value > targval + 0.0005:
                 score = 'fail'
-                print('fail: target = ' + str(score))
+                if debug:
+                    print('fail: target = ' + str(score))
             elif math.isnan(value):
                 score = 'fail'
 
@@ -241,7 +243,8 @@ def find_limits(spectype, spec, results, units, debug=False):
 
             if value != targval:
                 score = 'fail'
-                print('off-target failure')
+                if debug:
+                    print('off-target failure')
             elif math.isnan(value):
                 score = 'fail'
 
@@ -307,6 +310,7 @@ def incompleteresult(param, noplotmode=False):
 #-------------------------------------------------------------
 
 def addnewresult(param, resultdict):
+    replaced = False
     if 'results' in param:
         newresultlist = []
         paramresults = param['results']
@@ -315,8 +319,11 @@ def addnewresult(param, resultdict):
         for result in paramresults:
             if result['name'] == resultdict['name']:
                 newresultlist.append(resultdict)
+                replaced = True
             else:
                 newresultlist.append(result)
+        if replaced == False:
+            newresultlist.append(resultdict)
         param['results'] = newresultlist
     else:
         param['results'] = resultdict
@@ -603,6 +610,8 @@ def cace_collate(dsheet, param):
     # depends on where the source netlists came from.
 
     resultdict['name'] = runtime_options['netlist_source']
+    if debug:
+        print('Adding new result set ' + resultdict['name'] + ' for ' + param['name'])
     addnewresult(param, resultdict)
 
     # Return the annotated electrical parameter

--- a/cace/common/cace_regenerate.py
+++ b/cace/common/cace_regenerate.py
@@ -445,6 +445,17 @@ def regenerate_rcx_netlist(dsheet):
 
         rcfile = get_magic_rcfile(dsheet, magicfilename)
         newenv = os.environ.copy()
+
+        if 'PDK_ROOT' in dsheet:
+            pdk_root = dsheet['PDK_ROOT']
+        else:
+            pdk_root = get_pdk_root()
+
+        if 'PDK' in dsheet:
+            pdk = dsheet['PDK']
+        else:
+            pdk = get_pdk(magicfilename)
+
         if pdk_root and 'PDK_ROOT' not in newenv:
             newenv['PDK_ROOT'] = pdk_root
         if pdk and 'PDK' not in newenv:
@@ -555,9 +566,14 @@ def regenerate_lvs_netlist(dsheet, pex=False):
         gdspath = None
         gdsfilename = None
 
+    if pex == True:
+        nettype = 'pex'
+    else:
+        nettype = 'layout'
+
     # Layout-extracted netlist for LVS
     if 'netlist' in paths:
-        lvs_netlist_path = os.path.join(paths['netlist'], 'layout')
+        lvs_netlist_path = os.path.join(paths['netlist'], nettype)
         lvs_netlist = os.path.join(lvs_netlist_path, netlistname)
     else:
         lvs_netlist_path = None
@@ -568,7 +584,7 @@ def regenerate_lvs_netlist(dsheet, pex=False):
     if force_regenerate:
         need_lvs_extract = True
     else:
-        print("Checking for out-of-date LVS netlists.")
+        print('Checking for out-of-date ' + nettype + ' netlists.')
         valid_layoutpath = magicfilename if magicpath else gdsfilename
         need_lvs_extract = check_layout_out_of_date(lvs_netlist, valid_layoutpath, debug)
 


### PR DESCRIPTION
Added C-only parasitic extraction to the list of netlist source types from the pull-down menu at the top of the CACE GUI, and fixed an issue with new results not getting back into the datasheet when a parameter has one result already and the netlist type has changed.