### PR TITLE
Changed python "eval()" to "ast.literal_eval()" for security reasons.

### DIFF
--- a/cace/common/cace_gensim.py
+++ b/cace/common/cace_gensim.py
@@ -16,6 +16,7 @@
 # 
 
 import os
+import ast
 import sys
 import json
 import re
@@ -162,8 +163,8 @@ def twos_comp(val, bits):
 
 def bcount(condition, unit, start, stop, step):
     blen = len(start)
-    a = eval('0b' + start)
-    e = eval('0b' + stop)
+    a = ast.literal_eval('0b' + start)
+    e = ast.literal_eval('0b' + stop)
     if a > e:
         a = twos_comp(a, blen)
         e = twos_comp(e, blen)
@@ -182,8 +183,8 @@ def bcount(condition, unit, start, stop, step):
 #-----------------------------------------------------------------------
 
 def bshift(condition, unit, start, stop, step):
-    a = eval('0b' + start)
-    e = eval('0b' + stop)
+    a = ast.literal_eval('0b' + start)
+    e = ast.literal_eval('0b' + stop)
     if a > e:
         a = twos_comp(a, blen)
         e = twos_comp(e, blen)
@@ -961,7 +962,7 @@ def substitute(filename, paths, tool, template, dutpath, simvals, schemline, pdk
                         btest = int(bexpr)
                     except:
                         try:
-                            brackval = str(eval(bexpr))
+                            brackval = str(ast.literal_eval(bexpr))
                         except:
                             pass
                         else:

--- a/cace/common/layout_estimate.py
+++ b/cace/common/layout_estimate.py
@@ -18,6 +18,7 @@
 
 import os
 import re
+import ast
 import sys
 import subprocess
 
@@ -242,7 +243,7 @@ def layout_estimate(inputfile, library, rcfile, debug, logfile=''):
                             try:
                                 mult = int(parmval)
                             except ValueError:
-                                mult = eval(parmval)
+                                mult = ast.literal_eval(parmval)
                     else:
                         # Last one that isn't a parameter will be kept
                         devtype = token

--- a/cace/common/netlist_precheck.py
+++ b/cace/common/netlist_precheck.py
@@ -17,6 +17,7 @@
 
 import os
 import re
+import ast
 import sys
 import subprocess
 
@@ -213,7 +214,7 @@ def netlist_precheck(inputfile, pdkpath, library, debug=False, keep=False, logfi
                             try:
                                 mult = int(parmval)
                             except ValueError:
-                                mult = eval(parmval)
+                                mult = ast.literal_eval(parmval)
                     else:
                         # Last one that isn't a parameter will be kept
                         # (only applies to subcircuit instances)


### PR DESCRIPTION
Changed python "eval()" to "ast.literal_eval()" in all occurrences where it is used to evaluate expressions used in testbench schematics.  The intention was for eval() to resolve simple mathematical expressions, not to execute any general-purpose python code, and the use of the "safe" evaluation will prevent any accidental or malicious use of python code embedded in CACE testbenches.