### PR TITLE
Create initial CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,56 @@
+name: CI
+
+# Events that trigger workflow
+on:
+  # Runs on all pushes to branches
+  push:
+  # Runs on all PRs
+  pull_request:
+  # Runs every day at midnight UTC
+  schedule:
+    - cron: "0 0 * * *"
+  # Manual Dispatch
+  workflow_dispatch:
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v3
+      - name: Set Up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.8"
+      - name: Install Dependencies
+        run: make venv
+      - name: Lint
+        run: |
+          PATH=$PWD/venv/bin:$PATH make lint
+  build:
+    runs-on: ubuntu-22.04
+    needs: [lint]
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10"]
+      fail-fast: false
+    name: Build Package (Python ${{ matrix.python-version }})
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v3
+      - name: Set Up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Dependencies
+        run: make venv
+      - name: Build Package
+        run: |
+          PATH=$PWD/venv/bin:$PATH make build
+      - name: Install Package
+        run: |
+          PATH=$PWD/venv/bin:$PATH make install
+        - name: Run CACE
+        run: |
+          PATH=$PWD/venv/bin:$PATH cace --help

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,6 +51,6 @@ jobs:
       - name: Install Package
         run: |
           PATH=$PWD/venv/bin:$PATH make install
-        - name: Run CACE
+      - name: Run CACE
         run: |
           PATH=$PWD/venv/bin:$PATH cace --help

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,6 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-22.04
-    continue-on-error: true
     steps:
       - name: Check out repo
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-22.04
+    continue-on-error: true
     steps:
       - name: Check out repo
         uses: actions/checkout@v3
@@ -28,6 +29,7 @@ jobs:
       - name: Lint
         run: |
           PATH=$PWD/venv/bin:$PATH make lint
+
   build:
     runs-on: ubuntu-22.04
     needs: [lint]
@@ -54,3 +56,26 @@ jobs:
       - name: Run CACE
         run: |
           PATH=$PWD/venv/bin:$PATH cace --help
+
+  docs:
+    runs-on: ubuntu-22.04
+    needs: [lint]
+    name: Build Documentation
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v3
+      - name: Set Up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+      - name: Install Dependencies
+        run: make venv
+      - name: Build Package
+        run: |
+          PATH=$PWD/venv/bin:$PATH make build
+      - name: Install Package
+        run: |
+          PATH=$PWD/venv/bin:$PATH make install
+      - name: Build Documentation
+        run: |
+          make docs

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,7 +55,7 @@ jobs:
           PATH=$PWD/venv/bin:$PATH make install
       - name: Run CACE
         run: |
-          PATH=$PWD/venv/bin:$PATH cace --help
+          PATH=$PWD/venv/bin:$PATH cace -help
 
   docs:
     runs-on: ubuntu-22.04

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,6 @@ venv/manifest.txt: ./requirements_docs.txt ./requirements_dev.txt ./requirements
 	rm -rf venv
 	python3 -m venv ./venv
 	PYTHONPATH= ./venv/bin/python3 -m pip install --upgrade pip
-	PYTHONPATH= ./venv/bin/python3 -m pip install --upgrade wheel
 	PYTHONPATH= ./venv/bin/python3 -m pip install --upgrade -r ./requirements_docs.txt
 	PYTHONPATH= ./venv/bin/python3 -m pip install --upgrade -r ./requirements_dev.txt
 	PYTHONPATH= ./venv/bin/python3 -m pip install --upgrade -r ./requirements.txt


### PR DESCRIPTION
This PR sets up our initial CI to lint cace, build cace and simply run `cace -help`.

Note that #19 should be merged first.