### PR TITLE
Revert "Changed python "eval()" to "ast.literal_eval()" for security reasons."

### DIFF
--- a/cace/common/cace_gensim.py
+++ b/cace/common/cace_gensim.py
@@ -16,7 +16,6 @@
 # 
 
 import os
-import ast
 import sys
 import json
 import re
@@ -163,8 +162,8 @@ def twos_comp(val, bits):
 
 def bcount(condition, unit, start, stop, step):
     blen = len(start)
-    a = ast.literal_eval('0b' + start)
-    e = ast.literal_eval('0b' + stop)
+    a = eval('0b' + start)
+    e = eval('0b' + stop)
     if a > e:
         a = twos_comp(a, blen)
         e = twos_comp(e, blen)
@@ -183,8 +182,8 @@ def bcount(condition, unit, start, stop, step):
 #-----------------------------------------------------------------------
 
 def bshift(condition, unit, start, stop, step):
-    a = ast.literal_eval('0b' + start)
-    e = ast.literal_eval('0b' + stop)
+    a = eval('0b' + start)
+    e = eval('0b' + stop)
     if a > e:
         a = twos_comp(a, blen)
         e = twos_comp(e, blen)
@@ -962,7 +961,7 @@ def substitute(filename, paths, tool, template, dutpath, simvals, schemline, pdk
                         btest = int(bexpr)
                     except:
                         try:
-                            brackval = str(ast.literal_eval(bexpr))
+                            brackval = str(eval(bexpr))
                         except:
                             pass
                         else:

--- a/cace/common/layout_estimate.py
+++ b/cace/common/layout_estimate.py
@@ -18,7 +18,6 @@
 
 import os
 import re
-import ast
 import sys
 import subprocess
 
@@ -243,7 +242,7 @@ def layout_estimate(inputfile, library, rcfile, debug, logfile=''):
                             try:
                                 mult = int(parmval)
                             except ValueError:
-                                mult = ast.literal_eval(parmval)
+                                mult = eval(parmval)
                     else:
                         # Last one that isn't a parameter will be kept
                         devtype = token

--- a/cace/common/netlist_precheck.py
+++ b/cace/common/netlist_precheck.py
@@ -17,7 +17,6 @@
 
 import os
 import re
-import ast
 import sys
 import subprocess
 
@@ -214,7 +213,7 @@ def netlist_precheck(inputfile, pdkpath, library, debug=False, keep=False, logfi
                             try:
                                 mult = int(parmval)
                             except ValueError:
-                                mult = ast.literal_eval(parmval)
+                                mult = eval(parmval)
                     else:
                         # Last one that isn't a parameter will be kept
                         # (only applies to subcircuit instances)


### PR DESCRIPTION
Reverts efabless/cace#18.  The solution may have once been valid but not since python 3.7, making it useless for CACE.  There is a workaround that I will apply instead after reverting this change.