### PR TITLE
Disabled the use of os.setpgid()

### DIFF
--- a/cace/cace_gui.py
+++ b/cace/cace_gui.py
@@ -811,7 +811,8 @@ class CACECharacterize(ttk.Frame):
         )
 
         # Return all individual "Simulate" buttons to normal text
-        for simbutton in self.simbuttons.keys():
+        for simbname in self.simbuttons.keys():
+            simbutton = self.simbuttons[simbname]
             simbutton.configure(text='Simulate')
 
     def edit_param(self, param):
@@ -992,7 +993,13 @@ class CACECharacterize(ttk.Frame):
 
         # Diagnostic
         print('Simulating parameter ' + name)
-        runtime_options['pid'] = os.getpid()
+        # NOTE: Commenting out the following line prevents the use of
+        # the process ID to set a common group ID that can be used to
+        # stop simulations by sending a kill signal to all threads.
+        # The method is not working, and on some systems os.setpgid()
+        # will not run.
+        #
+        # runtime_options['pid'] = os.getpid()
         p = multiprocessing.Process(
             target=self.cace_process,
             args=(


### PR DESCRIPTION
Disabled the use of os.setpgid(), which is at best not working and at worst causing errors on some systems.  Will need to find another method for canceling ongoing simulations.  Also fixes a small error when setting button text from "(in progress)" back to "Simulate".