### PR TITLE
Fixed the setting of the current directory after reading a datasheet

### DIFF
--- a/cace/common/cace_regenerate.py
+++ b/cace/common/cace_regenerate.py
@@ -1269,13 +1269,13 @@ def regenerate_netlists(dsheet):
         made_lvs_netlist = True
         result = regenerate_lvs_netlist(dsheet)
 
-    made_schem_nelist = False
+    made_schem_netlist = False
     if (
         source == 'all'
         or source == 'schematic'
         or (source == 'best' and result == False)
     ):
-        made_schem_nelist = True
+        made_schem_netlist = True
         result = regenerate_schematic_netlist(dsheet)
 
     # If LVS is run while netlist source is RCX, then the LVS netlist should


### PR DESCRIPTION
Fixed the position of the code that sets the current working directory so that it always happens directly after reading a new datasheet, so that behavior is always consistent relative to the definition of the root path.  Also:  Fixed a typo that can cause a failure in the netlist regeneration.