### PR TITLE
Fix for schematics referenced from the project top-level directory

### DIFF
--- a/cace/cace_cli.py
+++ b/cace/cace_cli.py
@@ -437,16 +437,18 @@ def cace_run(datasheet, paramname=None):
         # routine to handle it.
 
         found = False
-        for eparam in datasheet['electrical_parameters']:
-            if eparam['name'] == paramname:
-                cace_run_eparam(datasheet, eparam)
-                found = True
-                break
-        for pparam in datasheet['physical_parameters']:
-            if pparam['name'] == paramname:
-                cace_run_pparam(datasheet, pparam)
-                found = True
-                break
+        if 'electrical_parameters' in datasheet:
+            for eparam in datasheet['electrical_parameters']:
+                if eparam['name'] == paramname:
+                    cace_run_eparam(datasheet, eparam)
+                    found = True
+                    break
+        if 'physical_parameters' in datasheet:
+            for pparam in datasheet['physical_parameters']:
+                if pparam['name'] == paramname:
+                    cace_run_pparam(datasheet, pparam)
+                    found = True
+                    break
 
         if not found:
             print('\nError:  No parameter named ' + paramname + ' found!')

--- a/cace/common/cace_regenerate.py
+++ b/cace/common/cace_regenerate.py
@@ -30,6 +30,7 @@ def printwarn(output):
     failrex = re.compile('.*failure', re.IGNORECASE)
     warnrex = re.compile('.*warning', re.IGNORECASE)
     errrex = re.compile('.*error', re.IGNORECASE)
+    missrex = re.compile('.*not found', re.IGNORECASE)
 
     errors = 0
     outlines = output.splitlines()
@@ -45,7 +46,10 @@ def printwarn(output):
         fmatch = failrex.match(line)
         if fmatch:
             errors += 1
-        if ematch or wmatch or fmatch:
+        mmatch = missrex.match(line)
+        if mmatch:
+            errors += 1
+        if ematch or wmatch or fmatch or mmatch:
             print(line)
     return errors
 
@@ -1179,7 +1183,8 @@ def regenerate_testbench(dsheet, testbenchpath, testbench):
     if pdk and 'PDK' not in newenv:
         newenv['PDK'] = pdk
 
-    xschemargs = ['xschem', '-n', '-s', '-r', '-x', '-q']
+    tclstr = set_xschem_paths(dsheet, '')
+    xschemargs = ['xschem', '-n', '-s', '-r', '-x', '-q', '--tcl', tclstr]
 
     # Use the PDK xschemrc file for xschem startup
     xschemrcfile = os.path.join(


### PR DESCRIPTION
Corrected one place where the code was supposed to be backwards-compatible with a previous method of having schematics referenced from the top level directory.  The top level directory was being added to xschem paths for netlist generation of the DUT but not for the testbench generation.