### PR TITLE
Fixed problem when parameter sections are not both defined.

### DIFF
--- a/cace/__version__.py
+++ b/cace/__version__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = '2.1.9'
+__version__ = '2.1.10'
 
 if __name__ == '__main__':
     print(__version__, end='')

--- a/cace/cace_cli.py
+++ b/cace/cace_cli.py
@@ -492,14 +492,15 @@ def cace_run(datasheet, paramname=None):
                     print('cace_run_all_[e|p]param failed with exception:')
                     print(e)
                     presult = None
-                if presult:
-                    poolresult.append(presult)
+                poolresult.append(presult)
 
         # The pool results may arrive in either order, so arrange them properly.
-        idx0 = poolresult[0][0]
-        idx1 = poolresult[1][0]
-        datasheet['electrical_parameters'] = poolresult[idx0][1:]
-        datasheet['physical_parameters'] = poolresult[idx1][1:]
+        if poolresult[0]:
+            idx0 = poolresult[0][0]
+            datasheet['electrical_parameters'] = poolresult[idx0][1:]
+        if poolresult[1]:
+            idx1 = poolresult[1][0]
+            datasheet['physical_parameters'] = poolresult[idx1][1:]
 
     return datasheet
 


### PR DESCRIPTION
Fixed a problem that occurs in multithreading scheduling when only one of the sections "electrical-parameters" or "physical-parameters" is present (also if neither is present).  The code was making the assumption that both exist and was looking for a list of two results.