### PR TITLE
Fix plot steps

### DIFF
--- a/cace/__version__.py
+++ b/cace/__version__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = '2.1.10'
+__version__ = '2.1.11'
 
 if __name__ == '__main__':
     print(__version__, end='')

--- a/cace/gui/editparam.py
+++ b/cace/gui/editparam.py
@@ -162,9 +162,11 @@ class EditParam(tkinter.Toplevel):
         dsheet = self.parent.datasheet
 
         # Get list of methods from testbench folder
-        dspath = os.path.split(self.parent.filename)[0]
+        # ("dspath" should be the same as "tbpath"---is there any case
+        # where it would not be?
+        # dspath = os.path.split(self.parent.filename)[0]
         paths = dsheet['paths']
-        tbpath = os.path.join(dspath, paths['root'], paths['testbench'])
+        tbpath = os.path.join(paths['root'], paths['testbench'])
         tbfiles = os.listdir(tbpath)
         methods = []
         for spicefile in tbfiles:

--- a/cace/gui/failreport.py
+++ b/cace/gui/failreport.py
@@ -594,6 +594,12 @@ class FailReport(tkinter.Toplevel):
                         ),
                     )
                     ToolTip(header, text='Reverse order of results')
+                elif labtext == 'testbench':
+                    header = ttk.Label(
+                        body,
+                        text=labtext,
+                        style='title.TLabel',
+                    )
                 else:
                     header = ttk.Button(
                         body,


### PR DESCRIPTION
Plotting over any stepped condition was known to be semi-broken after porting to off-platform;  testbenches were all merged together and the stepping was lost.  This has been corrected.  Plots can be made with any variable condition on the X-axis and will display the results over all other condition groups as additional curve traces in the same graph, with the key text corresponding to the unique set of conditions.