### PR TITLE
Added support for local dependencies

### DIFF
--- a/cace/__version__.py
+++ b/cace/__version__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = '2.1.11'
+__version__ = '2.1.12'
 
 if __name__ == '__main__':
     print(__version__, end='')

--- a/cace/common/cace_read.py
+++ b/cace/common/cace_read.py
@@ -73,6 +73,7 @@ def cace_read(filename, debug=False):
     listkeys = [
         'conditions',
         'default_conditions',
+        'dependencies',
         'variables',
         'pins',
         'measure',

--- a/cace/common/cace_regenerate.py
+++ b/cace/common/cace_regenerate.py
@@ -918,7 +918,10 @@ def set_xschem_paths(dsheet, symbolpath, tclstr=None):
                         dependency['path'], dependency['name']
                     )
                     if not os.path.isdir(dependdir):
-                        print('Error:  Cannot find xschem library in ' + dependency['name'])
+                        print(
+                            'Error:  Cannot find xschem library in '
+                            + dependency['name']
+                        )
                         print('Current directory is: ' + os.getcwd())
                         print('Dependdir is: ' + dependdir)
                         dependdir = None

--- a/cace/common/cace_regenerate.py
+++ b/cace/common/cace_regenerate.py
@@ -913,7 +913,17 @@ def set_xschem_paths(dsheet, symbolpath, tclstr=None):
                 dependdir = os.path.join(
                     dependency['path'], dependency['name'], 'xschem'
                 )
-                tcllist.append('append XSCHEM_LIBRARY_PATH :' + dependdir)
+                if not os.path.isdir(dependdir):
+                    dependdir = os.path.join(
+                        dependency['path'], dependency['name']
+                    )
+                    if not os.path.isdir(dependdir):
+                        print('Error:  Cannot find xschem library in ' + dependency['name'])
+                        print('Current directory is: ' + os.getcwd())
+                        print('Dependdir is: ' + dependdir)
+                        dependdir = None
+                if dependdir:
+                    tcllist.append('append XSCHEM_LIBRARY_PATH :' + dependdir)
 
     return ' ; '.join(tcllist)
 


### PR DESCRIPTION
Corrected "cace_read.py" to treat dependencies as a list of dictionaries, which it was supposed to (any example having more than one dependency would have shown this to be broken).  Modified "cace_regenerate.py" to check for *local* dependencies in the dependency list, which is dependencies inside the project.  This allows schematics to be spread across multiple directories.  Also, each dependency path is checked for an "xschem" subdirectory, but if that does not exist, then the dependency path itself is used. Any project can potentially set up xschem to find all of its files from one of these path choices.