### PR TITLE
Added "semilogx", "semilogy", and "loglog" to plot types.

### DIFF
--- a/cace/__version__.py
+++ b/cace/__version__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = '2.1.12'
+__version__ = '2.1.13'
 
 if __name__ == '__main__':
     print(__version__, end='')

--- a/cace/common/cace_makeplot.py
+++ b/cace/common/cace_makeplot.py
@@ -492,14 +492,41 @@ def cace_makeplot(dsheet, param, parent=None):
                 label=pdict['sdata'],
                 stacked=True,
             )
+        elif plottype == 'semilogx':
+            for i in traces:
+                aname = 'ydata' + str(i)
+                alabl = 'ylabel' + str(i)
+                ax.semilogx(
+                    xdata,
+                    pdict[aname],
+                    label=pdict['sdata'],
+                )
+        elif plottype == 'semilogy':
+            for i in traces:
+                aname = 'ydata' + str(i)
+                alabl = 'ylabel' + str(i)
+                ax.semilogy(
+                    xdata,
+                    pdict[aname],
+                    label=pdict['sdata'],
+                )
+        elif plottype == 'loglog':
+            for i in traces:
+                aname = 'ydata' + str(i)
+                alabl = 'ylabel' + str(i)
+                ax.loglog(
+                    xdata,
+                    pdict[aname],
+                    label=pdict['sdata'],
+                )
         else:
+            # plottype is 'xyplot'
             for i in traces:
                 aname = 'ydata' + str(i)
                 alabl = 'ylabel' + str(i)
                 ax.plot(
                     xdata,
                     pdict[aname],
-                    # label=pdict[alabl] + ' ' + pdict['sdata'],
                     label=pdict['sdata'],
                 )
 

--- a/cace/doc/format.txt
+++ b/cace/doc/format.txt
@@ -546,6 +546,12 @@ Plots
 	Plots are done with python matplotlib, so it must be a format
 	known to matplotlib.
 
+	type: <string>
+	The type of plot to make.  If this record is missing from the
+	dictionary, then plot type "xyplot" is assumed by default.
+	Otherwise, the value should be one of "xyplot", "histogram",
+	"semilogx", "semilogy", or "loglog".
+
 	xaxis: <name>
 	Condition to be plotted on the graph X axis, as determined
 	from the condition related to <name> in the "variables"

--- a/docs/source/formats/format_description.md
+++ b/docs/source/formats/format_description.md
@@ -543,6 +543,12 @@ Internal calculation (measurement) methods:
 	Plots are done with python matplotlib, so it must be a format
 	known to matplotlib.
 
+	type: <string>
+	The type of plot to make.  If this record is missing from the
+	dictionary, then plot type "xyplot" is assumed by default.
+	Otherwise, the value should be one of "xyplot", "histogram",
+	"semilogx", "semilogy", or "loglog".
+
 	xaxis: <name>
 	Condition to be plotted on the graph X axis, as determined
 	from the condition related to <name> in the "variables"


### PR DESCRIPTION
Added to the "type" values understood by the "plot" dictionary to include "semilogx", "semilogy", and "loglog", corresponding to the plot types of the same name in Matlab/octave/matplotlib.