### PR TITLE
ignore SIGUSR1 on windows

### DIFF
--- a/cace/cace_gui.py
+++ b/cace/cace_gui.py
@@ -2053,7 +2053,8 @@ def gui():
         else:
             arguments.append(item)
 
-    signal.signal(signal.SIGUSR1, signal.SIG_IGN)
+    if os.name != "nt":
+        signal.signal(signal.SIGUSR1, signal.SIG_IGN)
     root = tkinter.Tk()
     app = CACECharacterize(root)
 

--- a/cace/cace_gui.py
+++ b/cace/cace_gui.py
@@ -2053,7 +2053,7 @@ def gui():
         else:
             arguments.append(item)
 
-    if os.name != "nt":
+    if os.name != 'nt':
         signal.signal(signal.SIGUSR1, signal.SIG_IGN)
     root = tkinter.Tk()
     app = CACECharacterize(root)


### PR DESCRIPTION
cace-gui crash on windows with:
AttributeError: module 'signal' has no attribute 'SIGUSR1'
It seems that ignoring the instruction fix the issue.
I don't know the purpose of SIGUSR1 so maybe I miss something.
