### PR TITLE
Removed the 300 second timout for thread completion

### DIFF
--- a/cace/__version__.py
+++ b/cace/__version__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = '2.1.15'
+__version__ = '2.1.16'
 
 if __name__ == '__main__':
     print(__version__, end='')

--- a/cace/common/cace_launch.py
+++ b/cace/common/cace_launch.py
@@ -317,7 +317,11 @@ def cace_launch(dsheet, param):
 
             for result in results:
                 try:
-                    presult = result.get(timeout=300)
+                    # Note:  Previously used result.get(timeout=300).
+                    # This was intended to prevent hung simulations from
+                    # hanging CACE.  But with multiprocessing, the timeout
+                    # itself causes CACE to hang, making it less than useless.
+                    presult = result.get()
                 except Exception as e:
                     print('simulate_and_measure failed with exception:')
                     print(e)


### PR DESCRIPTION
Removed the 300 second timout from the result.get() call that merges threads from multiprocessing.  The timeout itself causes the process to hang, so all it accomplishes is to prevent any simulations from taking longer than 300 seconds to run.