### PR TITLE
Use argparse for argument parsing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,7 +54,7 @@ jobs:
           make install
       - name: Run CACE
         run: |
-          cace -help
+          cace --help
 
   docs:
     runs-on: ubuntu-22.04

--- a/cace/cace_cli.py
+++ b/cace/cace_cli.py
@@ -352,15 +352,15 @@ def cace_run_all_pparams(datasheet):
 # Run CACE on a characterization datasheet.
 #
 # "datasheet" is the CACE characterization dataset
-# "paramname" is an optional parameter name, which if present may
-# 	be the name of either an electrical parameter or a physical
-# 	parameter.  If omitted, then characterization is run on
+# "paramnames" is an optional list of parameter names, which if present may
+# 	be the names of electrical parameters or a physical
+# 	parameters.  If omitted, then characterization is run on
 # 	the full set of electrical and physical parameters in the
 # 	datasheet.
 # -----------------------------------------------------------------
 
 
-def cace_run(datasheet, paramnames=None):
+def cace_run(datasheet, paramnames=[]):
 
     if 'runtime_options' in datasheet:
         runtime_options = datasheet['runtime_options']

--- a/cace/cace_gui.py
+++ b/cace/cace_gui.py
@@ -955,7 +955,7 @@ class CACECharacterize(ttk.Frame):
             os.setpgid(os.getpid(), runtime_options['pid'])
             signal.signal(signal.SIGUSR1, child_process_exit)
 
-        charresult = cace_run(datasheet, name)
+        charresult = cace_run(datasheet, [name])
         charresult['simname'] = name
         self.queue.put(charresult)
         sys.stdout.flush()
@@ -1008,7 +1008,7 @@ class CACECharacterize(ttk.Frame):
         if name == 'check':
             # For the special keyword "check", do not multiprocess,
             # and return a pass/fail result according to the runtime status.
-            cace_run(dsheet, name)
+            cace_run(dsheet, [name])
             if 'status' in runtime_options:
                 status = runtime_options['status']
                 runtime_options.pop('status')

--- a/cace/common/cace_write.py
+++ b/cace/common/cace_write.py
@@ -850,7 +850,7 @@ def cace_generate_html(datasheet, filename=None, debug=False):
 
 def cace_summarize_result(param, result):
     spec = param['spec']
-    unit = param['unit']
+    unit = param['unit'] if 'unit' in param else ''
 
     keys = ['minimum', 'typical', 'maximum']
 
@@ -886,16 +886,17 @@ def cace_summarize_result(param, result):
 # Print a summary report of results from a datasheet
 #
 # "datasheet" is a CACE characterization dataset
-# "paramname" is the name of a single parameter to summarize,
+# "paramname" is a list of parameters to summarize,
 # 	or if it is None, then all parameters should be output.
 # ---------------------------------------------------------------
 
 
-def cace_summary(datasheet, paramname):
+def cace_summary(datasheet, paramnames):
 
-    if 'electrical_parameters' in datasheet:
-        for eparam in datasheet['electrical_parameters']:
-            if not paramname or paramname == eparam['name']:
+    # Summarize all parameters
+    if not paramnames:
+        if 'electrical_parameters' in datasheet:
+            for eparam in datasheet['electrical_parameters']:
                 print('Electrical parameter ' + eparam['name'])
                 if 'description' in eparam:
                     print('   ' + eparam['description'])
@@ -913,9 +914,8 @@ def cace_summary(datasheet, paramname):
                     else:
                         cace_summarize_result(eparam, results)
 
-    if 'physical_parameters' in datasheet:
-        for pparam in datasheet['physical_parameters']:
-            if not paramname or paramname == pparam['name']:
+        if 'physical_parameters' in datasheet:
+            for pparam in datasheet['physical_parameters']:
                 print('Physical parameter ' + pparam['name'])
                 if 'description' in pparam:
                     print('   ' + pparam['description'])
@@ -932,6 +932,49 @@ def cace_summary(datasheet, paramname):
                             cace_summarize_result(pparam, result)
                     else:
                         cace_summarize_result(pparam, results)
+
+    # Only summarize the parameters in the list
+    else:
+        for paramname in paramnames:
+            if 'electrical_parameters' in datasheet:
+                for eparam in datasheet['electrical_parameters']:
+                    if paramname == eparam['name']:
+                        print('Electrical parameter ' + eparam['name'])
+                        if 'description' in eparam:
+                            print('   ' + eparam['description'])
+                        if 'display' in eparam:
+                            print('   ' + eparam['display'])
+                        if 'spec' not in eparam:
+                            print('   (Parameter does not have a spec)')
+                        elif 'results' not in eparam:
+                            print('   (No results to report)')
+                        else:
+                            results = eparam['results']
+                            if isinstance(results, list):
+                                for result in eparam['results']:
+                                    cace_summarize_result(eparam, result)
+                            else:
+                                cace_summarize_result(eparam, results)
+
+            if 'physical_parameters' in datasheet:
+                for pparam in datasheet['physical_parameters']:
+                    if paramname == pparam['name']:
+                        print('Physical parameter ' + pparam['name'])
+                        if 'description' in pparam:
+                            print('   ' + pparam['description'])
+                        if 'display' in eparam:
+                            print('   ' + eparam['display'])
+                        if 'spec' not in pparam:
+                            print('   (Parameter does not have a spec)')
+                        elif 'results' not in pparam:
+                            print('   (No results to report)')
+                        else:
+                            results = pparam['results']
+                            if isinstance(results, list):
+                                for result in pparam['results']:
+                                    cace_summarize_result(pparam, result)
+                            else:
+                                cace_summarize_result(pparam, results)
 
 
 # ---------------------------------------------------------------

--- a/docs/source/usage/cace_cli.md
+++ b/docs/source/usage/cace_cli.md
@@ -7,7 +7,7 @@ CACE can be run directly from your command line:
 Where `<filename_in>` is a format 4.0 ASCII CACE file and `<filename_out>` is the name of the file to write.
 Options may be one of:
 
-```
+```console
 --source=schematic|layout|rcx|all|best
 --param=<parameter_name> <parameter_name> ...
 --force
@@ -25,7 +25,7 @@ With option `-source`, restrict characterization to the specific netlist source,
 layout extracted, or full R-C parasitic extracted. If not specified, then characterization is run on the full R-C
 parasitic extracted layout netlist if available, and the schematic captured netlist if not (option "best").
 
-```
+```console
 positional arguments:
   datasheet             format 4.0 ASCII CACE file
   outfile               name of the file to write

--- a/docs/source/usage/cace_cli.md
+++ b/docs/source/usage/cace_cli.md
@@ -2,19 +2,22 @@
 
 CACE can be run directly from your command line:
 
-	$ cace <filename_in> <filename_out> [options]
+	$ cace <filename_in> [<filename_out>] [options]
 
 Where `<filename_in>` is a format 4.0 ASCII CACE file and `<filename_out>` is the name of the file to write.
 Options may be one of:
 
-	  -source=schematic|layout|rcx|all|best
-	  -param=<parameter_name>
-	  -force
-	  -json
-	  -keep
-	  -debug
-	  -sequential
-	  -summary
+```
+--source=schematic|layout|rcx|all|best
+--param=<parameter_name> <parameter_name> ...
+--force
+--json
+--keep
+--debug
+--sequential
+--no-simulation
+--summary
+```
 
 When run from the top level, this program parses the CACE characterization file, runs simulations, and outputs a modified file annotated with characterization results.
 
@@ -22,22 +25,28 @@ With option `-source`, restrict characterization to the specific netlist source,
 layout extracted, or full R-C parasitic extracted. If not specified, then characterization is run on the full R-C
 parasitic extracted layout netlist if available, and the schematic captured netlist if not (option "best").
 
-	Option "-param=<parameter_name>" runs simulations on only
-	the named electrical or physical parameter.
+```
+positional arguments:
+  datasheet             format 4.0 ASCII CACE file
+  outfile               name of the file to write
 
-	Option "-force" forces new regeneration of all netlists.
-
-	Option "-json" generates an output file in JSON format.
-
-	Option "-keep" retains files generated for characterization.
-
-	Option "-noplot" will not generate any graphs.
-
-	Option "-debug" generates additional diagnostic output.
-
-	Option "-sequential" runs simulations sequentially.
-
-	Option "-nosim" does not re-run simulations if the output file exists.
-	   (Warning---does not check if simulations are out of date).
-
-	Option "-summary" prints a summary of results at the end.
+options:
+  -h, --help            show this help message and exit
+  -s {schematic,layout,rcx,all,best}, --source {schematic,layout,rcx,all,best}
+                        restricts characterization to the specific netlist source, which is either schematic
+                        capture layout extracted, or full R-C parasitic extracted. If not specified, then
+                        characterization is run on the full R-C parasitic extracted layout netlist if available,
+                        and the schematic captured netlist if not (option "best")
+  -p PARAMETER [PARAMETER ...], --parameter PARAMETER [PARAMETER ...]
+                        runs simulations on only the named electrical or physical parameters, by default it runs
+                        all parameters
+  -f, --force           forces new regeneration of all netlists
+  -j, --json            generates an output file in JSON format
+  -k, --keep            retains files generated for characterization
+  --no-plot             do not generate any graphs
+  --debug               generates additional diagnostic output
+  --sequential          runs simulations sequentially
+  --no-simulation       does not re-run simulations if the output file exists. (Warning: Does not check if
+                        simulations are out of date)
+  --summary             prints a summary of results at the end
+```

--- a/docs/source/usage/getting_started.md
+++ b/docs/source/usage/getting_started.md
@@ -73,7 +73,7 @@ $ make docs
 To host the docs, run:
 
 ```
-make host-docs
+$ make host-docs
 ```
 
 > [!NOTE]


### PR DESCRIPTION
This PR simplifies argument parsing by using the builtin module `argparse`

- cace: Allows to specify a list of parameters
    `cace cace/sky130_ef_ip__instramp.txt -s schematic --summary --parameter Idd_enabled psrr_100k `

- cace-gui: captures console output only if `--terminal` is passed (not even for a short time)

This is in preparation for the multiprocessing rewrite.