### PR TITLE
Fixed two issues deemed "severe"

### DIFF
--- a/cace/__version__.py
+++ b/cace/__version__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = '2.1.16'
+__version__ = '2.1.17'
 
 if __name__ == '__main__':
     print(__version__, end='')

--- a/cace/common/cace_makeplot.py
+++ b/cace/common/cace_makeplot.py
@@ -599,9 +599,18 @@ def cace_makeplot(dsheet, param, parent=None):
         else:
             canvas.print_figure(filename, bbox_inches='tight')
 
-    resultdict = {}
+    # Do not overwrite a result dictionary.  Only add an entry if no result
+    # dictionary exists.
+    netlist_source = runtime_options['netlist_source']
+    results = param['results']
+    if isinstance(results, dict):
+        results = [results]
+    try:
+        resultdict = next(item for item in results if item['name'] == netlist_source)
+    except:
+        resultdict = {}
     resultdict['status'] = 'done'
-    resultdict['name'] = runtime_options['netlist_source']
+    resultdict['name'] = netlist_source
     addnewresult(param, resultdict)
 
     return canvas

--- a/cace/common/cace_makeplot.py
+++ b/cace/common/cace_makeplot.py
@@ -606,7 +606,9 @@ def cace_makeplot(dsheet, param, parent=None):
     if isinstance(results, dict):
         results = [results]
     try:
-        resultdict = next(item for item in results if item['name'] == netlist_source)
+        resultdict = next(
+            item for item in results if item['name'] == netlist_source
+        )
     except:
         resultdict = {}
     resultdict['status'] = 'done'

--- a/cace/common/cace_write.py
+++ b/cace/common/cace_write.py
@@ -66,7 +66,7 @@ def generate_svg(datasheet):
             if 'PDK' in datasheet:
                 pdk = datasheet['PDK']
             else:
-                pdk = get_pdk(magicfilename)
+                pdk = get_pdk(None)
 
             newenv = os.environ.copy()
             if pdk_root and 'PDK_ROOT' not in newenv:
@@ -1449,6 +1449,16 @@ def cace_output_dict(itemdict, outlines, indent):
 def cace_write(datasheet, filename, doruntime=False):
     outlines = []
 
+    # Rewrite paths['root'] as the cwd relative to filename.
+    oldroot = None
+    if 'paths' in datasheet:
+        paths = datasheet['paths']
+        if 'root' in paths:
+            oldroot = paths['root']
+            filepath = os.path.split(filename)[0]
+            newroot = os.path.relpath(os.curdir, filepath)
+            paths['root'] = newroot
+
     newline = '#---------------------------------------------------'
     outlines.append(newline)
 
@@ -1463,6 +1473,10 @@ def cace_write(datasheet, filename, doruntime=False):
     outlines = cace_output_known_dict(
         'topmost', datasheet, outlines, doruntime, 0
     )
+
+    # Put back the old value of paths['root'] (should be '.')
+    if oldroot:
+        paths['root'] = oldroot
 
     # If filename is None, then write to stdout.
     if not filename:


### PR DESCRIPTION
Fixed two issues deemed "severe":
(1) cace_makeplot overwrites a "results" dictionary in a parameter,
    destroying min/typ/max values.  This happens when testbench
    simulation data are inspected by plotting them.
(2) cace_write writes the value of paths['root'] which is always
    '.' when it should be the location of the cwd relative to the
    location chosen for the output file.