### PR TITLE
GUI: exit when no datasheet is found

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+# 2.0.1
+
+## GUI
+
+- Don't crash if no datasheet is found
+
 # 2.2.0
 
 ## CLI

--- a/cace/__version__.py
+++ b/cace/__version__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = '2.2.0'
+__version__ = '2.2.1'
 
 if __name__ == '__main__':
     print(__version__, end='')

--- a/cace/cace_gui.py
+++ b/cace/cace_gui.py
@@ -502,7 +502,9 @@ class CACEGui(ttk.Frame):
 
     def find_datasheet(self, search_dir):
         debug = self.settings.get_debug()
-        self.simulation_manager.find_datasheet(search_dir, debug)
+        if self.simulation_manager.find_datasheet(search_dir, debug):
+            # Could not find a datasheet
+            return 1
         self.update_filename()
         self.adjust_datasheet_viewer_size()
         self.create_datasheet_view()
@@ -1250,7 +1252,8 @@ def gui():
         print('Setting datasheet to ' + args.datasheet)
         app.set_datasheet(args.datasheet)
     else:
-        app.find_datasheet(os.getcwd())
+        if app.find_datasheet(os.getcwd()):
+            sys.exit(0)
 
     # Start the main loop
     root.mainloop()

--- a/cace/common/simulation_manager.py
+++ b/cace/common/simulation_manager.py
@@ -122,10 +122,14 @@ class SimulationManager:
         self.default_runtime_options()
 
     def find_datasheet(self, search_dir, debug):
-        # Check the search_dir directory and determine if there
-        # is a .txt or .json file with the name of the directory, which
-        # is assumed to have the same name as the project circuit.  Also
-        # check subdirectories one level down.
+        """
+        Check the search_dir directory and determine if there
+        is a .txt or .json file with the name of the directory, which
+        is assumed to have the same name as the project circuit.  Also
+        check subdirectories one level down.
+        Returns 0 on success and 1 on failure.
+        """
+
         dirname = os.path.split(search_dir)[1]
         dirlist = os.listdir(search_dir)
 
@@ -138,7 +142,7 @@ class SimulationManager:
                     if basename == dirname:
                         print(f'Loading datasheet from {item}')
                         self.load_datasheet(item, debug)
-                        return
+                        return 0
 
             elif os.path.isdir(item):
                 subdirlist = os.listdir(item)
@@ -151,7 +155,7 @@ class SimulationManager:
                             if basename == dirname:
                                 print(f'Loading datasheet from {subitemref}')
                                 self.load_datasheet(subitemref, debug)
-                                return
+                                return 0
 
         # Look through all directories for a '.json' file
         # ('.txt') is preferred to ('.json')
@@ -163,7 +167,7 @@ class SimulationManager:
                     if basename == dirname:
                         print(f'Loading datasheet from {item}')
                         self.load_datasheet(item, debug)
-                        return
+                        return 0
 
             elif os.path.isdir(item):
                 subdirlist = os.listdir(item)
@@ -176,9 +180,10 @@ class SimulationManager:
                             if basename == dirname:
                                 print(f'Loading datasheet from {subitemref}')
                                 self.load_datasheet(subitemref, debug)
-                                return
+                                return 0
 
         print('No datasheet found in local project (JSON or text file).')
+        return 1
 
     def save_datasheet(self, path):
         if self.datasheet['runtime_options']['debug']:


### PR DESCRIPTION
Instead of printing an error message *and* crashing, just print the error message and exit.