### PR TITLE
Do not require a PDK to be specified in the datasheet.

### DIFF
--- a/cace/common/cace_compat.py
+++ b/cace/common/cace_compat.py
@@ -68,7 +68,7 @@ def cace_compat(datasheet, debug=False):
     if 'foundry' not in datasheet:
         # Pick up foundry name using PDK_ROOT
         pdk_root = get_pdk_root()
-        if pdk_root:
+        if pdk_root and 'PDK' in datasheet:
             pdk_config_file = (
                 pdk_root + '/' + datasheet['PDK'] + '/.config/nodeinfo.json'
             )

--- a/cace/common/cace_gensim.py
+++ b/cace/common/cace_gensim.py
@@ -1301,7 +1301,7 @@ def cace_gensim(dataset, param):
     runtime_options = dataset['runtime_options']
     debug = runtime_options['debug']
     source = runtime_options['netlist_source']
-    pdkname = dataset['PDK']
+    pdkname = dataset.get('PDK', "Unknown")
 
     # Grab values held in 'paths'
     paths = dataset['paths']

--- a/cace/common/simulation_manager.py
+++ b/cace/common/simulation_manager.py
@@ -370,7 +370,7 @@ class SimulationManager:
 
         paths = self.datasheet['paths']
         runtime_options = self.datasheet['runtime_options']
-        pdk = self.datasheet['PDK']
+        pdk = self.datasheet.get('PDK', None)
 
         if 'electrical_parameters' in self.datasheet:
             for param in self.datasheet['electrical_parameters']:


### PR DESCRIPTION
Some projects (i.e., PCB or other circuit simulation) do not have a PDK associated with them at all; they will use SPICE primitives, or other SUBCKTs, to do their work.  For these projects, there is no need for a `PDK` key in the config; enable that behavior.  This allows CACE to be used without a PDK installed at all.