### PR TITLE
Lower setuptools_scm requirements to >=7

### DIFF
--- a/cace/__version__.py
+++ b/cace/__version__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = '2.2.1'
+__version__ = '2.2.2'
 
 if __name__ == '__main__':
     print(__version__, end='')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ Homepage = "https://github.com/efabless/cace"
 Issues = "https://github.com/efabless/cace/issues"
 
 [build-system]
-requires = ["setuptools>=64", "setuptools_scm>=8"]
+requires = ["setuptools>=64", "setuptools_scm>=7"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
This makes it possible to package CACE with nix.

Fixes #58 