### PR TITLE
Scheduling improvements for parameters

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,24 @@
-# 2.0.1
+# 2.2.3
+
+## Common
+
+- Improve scheduling of parameters
+  - Simpler and more reliable
+- Queued parameters can now be canceled
+
+## GUI
+
+- While a simulation is running, the netlist source cannot be changed
+
+# 2.2.2
+
+## Common
+
+- Lower setuptools_scm requirement to >=7
+
+# 2.2.0
+
+# 2.2.1
 
 ## GUI
 

--- a/cace/__version__.py
+++ b/cace/__version__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = '2.2.2'
+__version__ = '2.2.3'
 
 if __name__ == '__main__':
     print(__version__, end='')

--- a/cace/common/electrical_parameter.py
+++ b/cace/common/electrical_parameter.py
@@ -55,7 +55,9 @@ class ElectricalParameter(threading.Thread):
 
         self.queued_jobs = []
         self.new_testbenches = []
+
         self.canceled = False
+        self.done = False
 
         super().__init__(*args, **kwargs)
 
@@ -133,6 +135,9 @@ class ElectricalParameter(threading.Thread):
         self.param['testbenches'] = self.new_testbenches
 
         self.postprocess()
+
+        # Set done before calling cb
+        self.done = True
 
         if self.cb:
             self.cb(self.param['name'])

--- a/cace/common/physical_parameter.py
+++ b/cace/common/physical_parameter.py
@@ -47,6 +47,7 @@ class PhysicalParameter(threading.Thread):
         self.runtime_options = runtime_options
 
         self.canceled = False
+        self.done = False
 
         super().__init__(*args, **kwargs)
 
@@ -70,6 +71,9 @@ class PhysicalParameter(threading.Thread):
 
         print(f'{self.param["name"]}: Evaluating physical parameter')
         cace_evaluate(self.datasheet, self.param)
+
+        # Set done before calling cb
+        self.done = True
 
         if self.cb:
             self.cb(self.param['name'])

--- a/cace/common/simulation_manager.py
+++ b/cace/common/simulation_manager.py
@@ -289,7 +289,7 @@ class SimulationManager:
     def validate_runtime_options(self):
         """Make sure the runtime options contain valid values"""
 
-        valid_sources = ['schematic', 'layout', 'pex', 'rcx']
+        valid_sources = ['schematic', 'layout', 'pex', 'rcx', 'best']
 
         if (
             not self.datasheet['runtime_options']['netlist_source']


### PR DESCRIPTION
Follow-up to #48

There are now two lists for queued and running parameters protected by locks.
All in all the code was cleaned up and queued parameters can now also be cancelled.
In addition, the netlist source can no longer be changed when parameters are running.

Fixes: #50 #51