### PR TITLE
Add a Markdown summary

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,14 @@
+# 2.2.4
+
+## Common
+
+- Add `markdown_summary` to `simulation_manager`
+
+## CLI
+
+- Call `markdown_summary` at the end and print to stdout
+- Add `--markdown` argument to print to file
+
 # 2.2.3
 
 ## Common

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,12 +2,12 @@
 
 ## Common
 
-- Add `markdown_summary` to `simulation_manager`
+- Add `markdown_summary`
 
 ## CLI
 
 - Call `markdown_summary` at the end and print to stdout
-- Add `--markdown` argument to print to file
+- Change `--summary` argument to print to file
 
 # 2.2.3
 

--- a/cace/__version__.py
+++ b/cace/__version__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = '2.2.3'
+__version__ = '2.2.4'
 
 if __name__ == '__main__':
     print(__version__, end='')

--- a/cace/cace_cli.py
+++ b/cace/cace_cli.py
@@ -113,6 +113,11 @@ def cli():
         action='store_true',
         help='prints a summary of results at the end',
     )
+    parser.add_argument(
+        '--markdown',
+        action='store_true',
+        help='writes summary.md at the end',
+    )
 
     # Parse arguments
     args = parser.parse_args()
@@ -180,6 +185,14 @@ def cli():
         print('CACE Summary of results:')
         print('------------------------')
         simulation_manager.summarize_datasheet(args.parameter)
+
+    # Print the summary to stdout
+    simulation_manager.markdown_summary()
+
+    # Print the summary to a file
+    if args.markdown:
+        with open('summary.md', 'w') as ofile:
+            simulation_manager.markdown_summary(ofile)
 
 
 if __name__ == '__main__':

--- a/cace/cace_cli.py
+++ b/cace/cace_cli.py
@@ -110,13 +110,7 @@ def cli():
     )
     parser.add_argument(
         '--summary',
-        action='store_true',
-        help='prints a summary of results at the end',
-    )
-    parser.add_argument(
-        '--markdown',
-        action='store_true',
-        help='writes summary.md at the end',
+        help='output path for the summary e.g. final/summary.md',
     )
 
     # Parse arguments
@@ -157,7 +151,7 @@ def cli():
             print(f'Running simulation for: {args.parameter}')
 
         for pname in args.parameter:
-            simulation_manager.queue_simulation(pname)
+            simulation_manager.queue_parameter(pname)
     # Queue all parameters
     else:
         pnames = simulation_manager.get_all_pnames()
@@ -180,19 +174,22 @@ def cli():
     if args.outfile:
         simulation_manager.save_datasheet(args.outfile)
 
-    if args.summary:
-        print('')
-        print('CACE Summary of results:')
-        print('------------------------')
-        simulation_manager.summarize_datasheet(args.parameter)
-
     # Print the summary to stdout
-    simulation_manager.markdown_summary()
+    simulation_manager.summarize_datasheet()
 
     # Print the summary to a file
-    if args.markdown:
-        with open('summary.md', 'w') as ofile:
-            simulation_manager.markdown_summary(ofile)
+    if args.summary:
+        dirname = os.path.dirname(args.summary) or os.getcwd()
+        filename = os.path.basename(args.summary)
+
+        # Check whether path to file exists
+        if os.path.isdir(dirname):
+            with open(os.path.join(dirname, filename), 'w') as ofile:
+                simulation_manager.summarize_datasheet(ofile)
+        else:
+            print(
+                f"Couldn't write summary, invalid path: {os.path.dirname(args.summary)}"
+            )
 
 
 if __name__ == '__main__':

--- a/cace/common/simulation_manager.py
+++ b/cace/common/simulation_manager.py
@@ -211,6 +211,191 @@ class SimulationManager:
     def summarize_datasheet(self, pnames=[]):
         cace_summary(self.datasheet, pnames)
 
+    def markdown_summary(self, file=None):
+        """
+        Print a brief summary to either stdout or any file that is passed.
+        The summary is formatted in Markdown and can be viewed
+        """
+        print('\n# CACE Summary\n', file=file)
+
+        print(
+            f'**general**\n\n'
+            f'- name: {self.datasheet["name"]}\n'
+            f'- description: {self.datasheet["description"]}\n'
+            f'- commit: {self.datasheet["commit"]}\n'
+            f'- PDK: {self.datasheet["PDK"]}\n'
+            f'- cace_format: {self.datasheet["cace_format"]}\n',
+            file=file,
+        )
+
+        print(
+            f'**authorship**\n\n'
+            f'- designer: {self.datasheet["authorship"]["designer"]}\n'
+            f'- company: {self.datasheet["authorship"]["company"]}\n'
+            f'- creation_date: {self.datasheet["authorship"]["creation_date"]}\n'
+            f'- license: {self.datasheet["authorship"]["license"]}\n',
+            file=file,
+        )
+
+        print('## Electrical Parameters\n', file=file)
+
+        # Spacings
+        sp = [20, 20, 9, 9, 9, 9, 9, 9, 8]
+
+        print(
+            f'| {"Parameter": ^{sp[0]}} | {"Testbench": ^{sp[1]}} | {"Min Limit": ^{sp[2]}} | {"Min Value": ^{sp[3]}} | {"Typ Limit": ^{sp[4]}} | {"Typ Value": ^{sp[5]}} | {"Max Limit": ^{sp[6]}} | {"Max Value": ^{sp[7]}} | {"Status": ^{sp[8]}} |',
+            file=file,
+        )
+        print(
+            f'| :{"-"*(sp[0]-1)} | :{"-"*(sp[1]-1)} | :{"-"*(sp[3]-2)}: | :{"-"*(sp[3]-2)}: | :{"-"*(sp[4]-2)}: | :{"-"*(sp[5]-2)}: | :{"-"*(sp[6]-2)}: | :{"-"*(sp[7]-2)}: | :{"-"*(sp[8]-2)}: |',
+            file=file,
+        )
+
+        if 'electrical_parameters' in self.datasheet:
+            for eparam in self.datasheet['electrical_parameters']:
+
+                min_limit = ''
+                typ_limit = ''
+                max_limit = ''
+
+                if 'spec' in eparam:
+                    if 'minimum' in eparam['spec']:
+                        min_limit = eparam['spec']['minimum']
+
+                        if isinstance(min_limit, list):
+                            min_limit = min_limit[0]
+
+                    if 'typical' in eparam['spec']:
+                        typ_limit = eparam['spec']['typical']
+
+                        if isinstance(typ_limit, list):
+                            typ_limit = typ_limit[0]
+
+                    if 'maximum' in eparam['spec']:
+                        max_limit = eparam['spec']['maximum']
+
+                        if isinstance(max_limit, list):
+                            max_limit = max_limit[0]
+
+                min_value = ''
+                typ_value = ''
+                max_value = ''
+
+                if 'results' in eparam:
+                    passing = True
+
+                    if 'minimum' in eparam['results']:
+                        min_value = eparam['results']['minimum'][0]
+
+                        if eparam['results']['minimum'][1] != 'pass':
+                            passing = False
+
+                    if 'typical' in eparam['results']:
+                        typ_value = eparam['results']['typical'][0]
+
+                        if eparam['results']['typical'][1] != 'pass':
+                            passing = False
+
+                    if 'maximum' in eparam['results']:
+                        max_value = eparam['results']['maximum'][0]
+
+                        if eparam['results']['maximum'][1] != 'pass':
+                            passing = False
+
+                testbench = ''
+
+                status = 'Pass ✅' if passing else 'Fail ❌'
+
+                if eparam['status'] == 'skip':
+                    status = 'Skip 🟧'
+
+                if 'simulate' in eparam:
+                    testbench = eparam['simulate']['template']
+
+                print(
+                    f'| {eparam["name"]: <{sp[0]}} | {testbench: <{sp[1]}} | {min_limit: ^{sp[2]}} | {min_value: ^{sp[3]}} | {typ_limit: ^{sp[4]}} | {typ_value: ^{sp[5]}} | {max_limit: ^{sp[6]}} | {max_value: ^{sp[7]}} | {status: ^{sp[8]-1}} |',
+                    file=file,
+                )
+
+        print('\n## Physical Parameters\n', file=file)
+
+        print(
+            f'| {"Parameter": ^{sp[0]}} | {"Testbench": ^{sp[1]}} | {"Min Limit": ^{sp[2]}} | {"Min Value": ^{sp[3]}} | {"Typ Limit": ^{sp[4]}} | {"Typ Value": ^{sp[5]}} | {"Max Limit": ^{sp[6]}} | {"Max Value": ^{sp[7]}} | {"Status": ^{sp[8]}} |',
+            file=file,
+        )
+        print(
+            f'| :{"-"*(sp[0]-1)} | :{"-"*(sp[1]-1)} | :{"-"*(sp[3]-2)}: | :{"-"*(sp[3]-2)}: | :{"-"*(sp[4]-2)}: | :{"-"*(sp[5]-2)}: | :{"-"*(sp[6]-2)}: | :{"-"*(sp[7]-2)}: | :{"-"*(sp[8]-2)}: |',
+            file=file,
+        )
+
+        if 'physical_parameters' in self.datasheet:
+            for pparam in self.datasheet['physical_parameters']:
+
+                min_limit = ''
+                typ_limit = ''
+                max_limit = ''
+
+                if 'spec' in pparam:
+                    if 'minimum' in pparam['spec']:
+                        min_limit = pparam['spec']['minimum']
+
+                        if isinstance(min_limit, list):
+                            min_limit = min_limit[0]
+
+                    if 'typical' in pparam['spec']:
+                        typ_limit = pparam['spec']['typical']
+
+                        if isinstance(typ_limit, list):
+                            typ_limit = typ_limit[0]
+
+                    if 'maximum' in pparam['spec']:
+                        max_limit = pparam['spec']['maximum']
+
+                        if isinstance(max_limit, list):
+                            max_limit = max_limit[0]
+
+                min_value = ''
+                typ_value = ''
+                max_value = ''
+
+                if 'results' in pparam:
+                    passing = True
+
+                    if 'minimum' in pparam['results']:
+                        min_value = pparam['results']['minimum'][0]
+
+                        if pparam['results']['minimum'][1] != 'pass':
+                            passing = False
+
+                    if 'typical' in pparam['results']:
+                        typ_value = pparam['results']['typical'][0]
+
+                        if pparam['results']['typical'][1] != 'pass':
+                            passing = False
+
+                    if 'maximum' in pparam['results']:
+                        max_value = pparam['results']['maximum'][0]
+
+                        if pparam['results']['maximum'][1] != 'pass':
+                            passing = False
+
+                testbench = ''
+
+                status = 'Pass ✅' if passing else 'Fail ❌'
+
+                if pparam['status'] == 'skip':
+                    status = 'Skip 🟧'
+
+                if 'simulate' in pparam:
+                    testbench = pparam['simulate']['template']
+
+                print(
+                    f'| {pparam["name"]: <{sp[0]}} | {testbench: <{sp[1]}} | {min_limit: ^{sp[2]}} | {min_value: ^{sp[3]}} | {typ_limit: ^{sp[4]}} | {typ_value: ^{sp[5]}} | {max_limit: ^{sp[6]}} | {max_value: ^{sp[7]}} | {status: ^{sp[8]-1}} |',
+                    file=file,
+                )
+
+        print('\n', file=file)
+
     def generate_html(self):
         debug = self.get_runtime_options('debug')
         cace_generate_html(self.datasheet, None, debug)


### PR DESCRIPTION
This PR adds a Markdown summary. The short summary is always printed to stdout at the end of `cace-cli`. In addition, a summary file is created by passing a file path to `--summary`.

<details><summary>

View Summary

</summary>

# CACE Summary

**general**

- name: sky130_ef_ip__instramp
- description: Rail-to-rail driver instrumentation amplifier
- commit: N/A
- PDK: sky130A
- cace_format: 4.0

**authorship**

- designer: Tim Edwards
- company: Efabless Corporation
- creation_date: January 5, 2024
- license: Apache 2.0

**netlist source**: schematic

## Electrical Parameters

|      Parameter       |      Testbench       | Min Limit  |  Min Value   | Typ Target |  Typ Value   | Max Limit  |  Max Value   |  Status  |
| :------------------- | :------------------- | ---------: | -----------: | ---------: | -----------: | ---------: | -----------: | :------: |
| Idd_enabled          | dccurrent_vdd.spice  |        any |     4.217 µA |     170 µA |     110.7 µA |     250 µA |     110.7 µA | Pass ✅  |
| Idd_dynamic          | dccurrent_dyn.spice  |        any |     4.032 µA |      40 µA |     42.46 µA |    5000 µA |      2736 µA | Pass ✅  |
| Idd_disabled         | dccurrent_vdd.spice  |        any |  0.005245 µA |     170 µA |  0.007469 µA |     250 µA |  0.008366 µA | Pass ✅  |
| Vol                  | voltage_out.spice    |            |              |        any |              |      0.1 V |              | Skip 🟧  |
| Voh                  | voltage_out.spice    |      2.4 V |              |        any |              |            |              | Skip 🟧  |
| offset_error         | input_offset.spice   |    -6 %FSR |              |     0 %FSR |              |   0.5 %FSR |              | Skip 🟧  |
| avo                  | avo.spice            |     100 dB |              |     125 dB |              |     125 dB |              | Skip 🟧  |
| gain_bandwidth       | gbw.spice            |    0.3 MHz |              |      4 MHz |              |      7 MHz |              | Skip 🟧  |
| slewrate_rise        | slew_rise.spice      |   0.5 V/µs |              |    12 V/µs |              |    30 V/µs |              | Skip 🟧  |
| slewrate_fall        | slew_fall.spice      |     1 V/µs |              |    25 V/µs |              |    45 V/µs |              | Skip 🟧  |
| full_power_bandwidth | slew_fall.spice      |        any |              |    2.5 MHz |              |        any |              | Skip 🟧  |
| phase_margin         | gbw.spice            |      100 ° |              |      160 ° |              |        any |              | Skip 🟧  |
| gain_margin          | gbw.spice            |        any |      -129 dB |    -100 dB |      -116 dB |        any |    -115.3 dB | Pass ✅  |
| equiv_noise_1k       | eqvnoise.spice       |        any |              | 280 nV/√Hz |              |        any |              | Skip 🟧  |
| equiv_noise_10k      | eqvnoise.spice       |        any |              | 100 nV/√Hz |              |        any |              | Skip 🟧  |
| cmrr_100k            | cmrr.spice           |        any |              |        any |              |     -40 dB |              | Skip 🟧  |
| psrr_100k            | psrr.spice           |        any |              |        any |              |     -45 dB |              | Skip 🟧  |
| transient_response   | transient.spice      |            |              |            |              |            |              | Skip 🟧  |

## Physical Parameters

|      Parameter       |         Tool         | Min Limit  |  Min Value   | Typ Target |  Typ Value   | Max Limit  |  Max Value   |  Status  |
| :------------------- | :------------------- | ---------: | -----------: | ---------: | -----------: | ---------: | -----------: | :------: |
| area                 | cace_area            |            |              |            |              |  50000 µm² |              | Skip 🟧  |
| LVS_errors           | cace_lvs             |            |              |            |              |          0 |            0 | Pass ✅  |
| DRC_errors           | cace_drc             |            |              |            |              |          0 |              | Skip 🟧  |

</details>

