### PR TITLE
Restore functionality of `sequential` runtime option

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+# 2.2.6
+
+## Common
+
+- Restored functionality of `sequential` runtime option
+
 # 2.2.5
 
 ## CLI

--- a/cace/__version__.py
+++ b/cace/__version__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = '2.2.5'
+__version__ = '2.2.6'
 
 if __name__ == '__main__':
     print(__version__, end='')

--- a/cace/common/simulation_job.py
+++ b/cace/common/simulation_job.py
@@ -39,6 +39,7 @@ class SimulationJob(threading.Thread):
         self.spiceproc = None
 
         super().__init__(*args, **kwargs)
+        self._return = None
 
     def cancel(self, cancel_cb):
         # print(f'{self.param["name"]}: Cancel simulation: {self.testbenchlist}')
@@ -112,7 +113,13 @@ class SimulationJob(threading.Thread):
                 if os.path.isfile(outfilename):
                     os.remove(outfilename)
 
-        return tbzero if simulations > 0 else None
+        # For when the join function is called
+        self._return = tbzero if simulations > 0 else None
+        return self._return
+
+    def join(self, *args):
+        threading.Thread.join(self, *args)
+        return self._return
 
     def collate_after_simulation(self, param, collnames, testbenchlist, debug):
         # Sanity check:  If there is only one testbench, then there is

--- a/cace/gui/consoletext.py
+++ b/cace/gui/consoletext.py
@@ -40,6 +40,9 @@ class ConsoleText(tkinter.Text):
         def write(self, str):
             self.text_area.write(str, True)
 
+        def flush(self):
+            pass
+
     def __init__(self, master=None, cnf={}, **kw):
         """See the __init__ for Tkinter.Text."""
 


### PR DESCRIPTION
Reenables `--sequential` for CLI and "Simulate single-threaded" for GUI.