### PR TITLE
Add support for new YAML datasheet format

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,14 +3,13 @@
 ## Common
 
 - Remove JSON datasheet format
-- Add YAML datasheet format
-- Remove `cace_compat.py`, as JSON is not supported anymore
-- Remove standalone `cace_read.py` and `cace_write.py`
+- Add YAML datasheet format, set as default
+- Remove cli interface from `cace_read.py` and `cace_write.py`
 
 ## GUI
 
 - Remove `JSON` in the file picker
-- Remove `YAML` in the file picker
+- Add `YAML` to the file picker
 - Remove bit-rotted `load_results`
 
 ## CLI

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,22 @@
+# 2.3.0
+
+## Common
+
+- Remove JSON datasheet format
+- Add YAML datasheet format
+- Remove `cace_compat.py`, as JSON is not supported anymore
+- Remove standalone `cace_read.py` and `cace_write.py`
+
+## GUI
+
+- Remove `JSON` in the file picker
+- Remove `YAML` in the file picker
+- Remove bit-rotted `load_results`
+
+## CLI
+
+- Remove `--json` argument
+
 # 2.2.7
 
 ## Common

--- a/cace/__version__.py
+++ b/cace/__version__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = '2.2.7'
+__version__ = '2.3.0'
 
 if __name__ == '__main__':
     print(__version__, end='')

--- a/cace/cace_cli.py
+++ b/cace/cace_cli.py
@@ -46,12 +46,12 @@ def cli():
 
     # positional argument, optional
     parser.add_argument(
-        'datasheet_in', nargs='?', help='input specification datasheet (YAML)'
+        'datasheet', nargs='?', help='input specification datasheet (YAML)'
     )
 
     # positional argument, optional
     parser.add_argument(
-        'datasheet_out',
+        'output',
         nargs='?',
         help='output specification datasheet (YAML)',
     )
@@ -143,12 +143,6 @@ def cli():
         'parallel_parameters', args.parallel_parameters
     )
 
-    # Add the name of the file to the top-level dictionary
-    if args.datasheet:
-        simulation_manager.set_runtime_options(
-            'filename', os.path.split(args.datasheet)[1]
-        )
-
     # Queue specified parameters
     if args.parameter:
         if args.debug:
@@ -175,8 +169,8 @@ def cli():
     if args.debug:
         print('Done with CACE simulations and evaluations.')
 
-    if args.outfile:
-        simulation_manager.save_datasheet(args.outfile)
+    if args.output:
+        simulation_manager.save_datasheet(args.output)
 
     # Print the summary to stdout
     simulation_manager.summarize_datasheet()

--- a/cace/cace_cli.py
+++ b/cace/cace_cli.py
@@ -44,13 +44,17 @@ def cli():
         '--version', action='version', version=f'%(prog)s {__version__}'
     )
 
-    # positional argument
+    # positional argument, optional
     parser.add_argument(
-        'datasheet', nargs='?', help='format 4.0 ASCII CACE file'
+        'datasheet_in', nargs='?', help='input specification datasheet (YAML)'
     )
 
     # positional argument, optional
-    parser.add_argument('outfile', nargs='?', help='name of the file to write')
+    parser.add_argument(
+        'datasheet_out',
+        nargs='?',
+        help='output specification datasheet (YAML)',
+    )
 
     parser.add_argument(
         '-s',
@@ -83,12 +87,6 @@ def cli():
         '--force',
         action='store_true',
         help='forces new regeneration of all netlists',
-    )
-    parser.add_argument(
-        '-j',
-        '--json',
-        action='store_true',
-        help='generates an output file in JSON format',
     )
     parser.add_argument(
         '-k',
@@ -136,7 +134,6 @@ def cli():
     # Set runtime options
     simulation_manager.set_runtime_options('debug', args.debug)
     simulation_manager.set_runtime_options('force', args.force)
-    simulation_manager.set_runtime_options('json', args.json)
     simulation_manager.set_runtime_options('keep', args.keep)
     simulation_manager.set_runtime_options('noplot', args.no_plot)
     simulation_manager.set_runtime_options('nosim', args.no_simulation)

--- a/cace/cace_gui.py
+++ b/cace/cace_gui.py
@@ -1123,10 +1123,16 @@ def gui():
 
     # on/off flag, optional
     parser.add_argument(
-        '-t',
         '--terminal',
         action='store_true',
         help='write all output to the terminal, not the window',
+    )
+
+    # on/off flag, optional
+    parser.add_argument(
+        '--debug',
+        action='store_true',
+        help='generates additional diagnostic output',
     )
 
     # Parse arguments
@@ -1138,6 +1144,10 @@ def gui():
 
     if not args.terminal:
         app.capture_output()
+
+    if args.debug:
+        print('Enabling debug output.')
+        app.settings.set_debug(True)
 
     if args.datasheet:
         print('Setting datasheet to ' + args.datasheet)

--- a/cace/common/cace_collate.py
+++ b/cace/common/cace_collate.py
@@ -62,8 +62,8 @@ def find_limits(spectype, spec, results, units, debug=False):
         target = spec[0]
         penalty = spec[1] if len(spec) > 1 else 'pass'
         calcrec = spec[2] if len(spec) > 2 else spectype
-    elif isinstance(spec, str):
-        target = spec
+    else:
+        target = str(spec)
         penalty = 'pass'
         calcrec = spectype
 

--- a/cace/common/cace_read.py
+++ b/cace/common/cace_read.py
@@ -296,9 +296,6 @@ def cace_read_yaml(filename, debug=False):
     with open(filename, 'r') as ifile:
         datasheet = yaml.safe_load(ifile)
 
-    if debug:
-        print(datasheet)
-
     # For compatibility convert dictionaries to arrays with
     # dictionaries containing the key inside "name"
     # TODO Remove this step and change the remaining code
@@ -336,7 +333,7 @@ def cace_read_yaml(filename, debug=False):
             for key, value in parameter['variables'].items():
                 value['name'] = key
                 new_variables.append(value)
-        parameter['variables'] = new_variables
+            parameter['variables'] = new_variables
 
     # Convert simulate in electrical_parameters
     for parameter in datasheet['electrical_parameters'].values():
@@ -434,12 +431,6 @@ def cace_read_yaml(filename, debug=False):
     # Convert dependencies TODO
     if not new_datasheet['dependencies']:
         new_datasheet['dependencies'] = []
-
-    if debug:
-        import pprint
-
-        pp = pprint.PrettyPrinter(depth=4)
-        pp.pprint(new_datasheet)
 
     # TODO Remove runtime options from datasheet
     # Set up runtime options in the dictionary before returning.

--- a/cace/common/cace_read.py
+++ b/cace/common/cace_read.py
@@ -17,8 +17,7 @@ import re
 import os
 import sys
 import json
-
-from .cace_compat import *
+import yaml
 
 # Replace special character specifications with unicode characters
 
@@ -289,68 +288,169 @@ def cace_read(filename, debug=False):
     return curdict
 
 
-# Print usage statement
+def cace_read_yaml(filename, debug=False):
+    if not os.path.isfile(filename):
+        print('Error:  No such file ' + filename)
+        return {}
 
+    with open(filename, 'r') as ifile:
+        datasheet = yaml.safe_load(ifile)
 
-def usage():
-    print('Usage:')
-    print('')
-    print('cace_read.py <filename>')
-    print('  Where <filename> is a format 4.0 ASCII CACE file.')
-    print('')
-    print('When run from the top level, this program parses the CACE')
-    print('file and reports any syntax errors.  Otherwise it is meant')
-    print('to be called internally by the CACE system to read a file')
-    print('and return a dictionary of the contents.')
+    if debug:
+        print(datasheet)
 
+    # For compatibility convert dictionaries to arrays with
+    # dictionaries containing the key inside "name"
+    # TODO Remove this step and change the remaining code
+    # in CACE to work with dictionaries
 
-# Top level call to cace_read.py
-# If called from the command line
+    # Copy header
+    new_datasheet = {}
+    new_datasheet['name'] = datasheet['name']
+    new_datasheet['description'] = datasheet['description']
+    new_datasheet['commit'] = datasheet['commit']
+    new_datasheet['PDK'] = datasheet['PDK']
+    new_datasheet['cace_format'] = datasheet['cace_format']
+    new_datasheet['authorship'] = datasheet['authorship']
+    new_datasheet['paths'] = datasheet['paths']
+    new_datasheet['dependencies'] = datasheet['dependencies']
 
-if __name__ == '__main__':
-    options = []
-    arguments = []
-    for item in sys.argv[1:]:
-        if item.find('-', 0) == 0:
-            options.append(item)
+    # Convert pins
+    new_datasheet['pins'] = []
+    for key, value in datasheet['pins'].items():
+        value['name'] = key
+        new_datasheet['pins'].append(value)
+
+    # Convert conditions in electrical_parameters
+    for parameter in datasheet['electrical_parameters'].values():
+        new_conditions = []
+        for key, value in parameter['conditions'].items():
+            value['name'] = key
+            new_conditions.append(value)
+        parameter['conditions'] = new_conditions
+
+    # Convert variables in electrical_parameters
+    for parameter in datasheet['electrical_parameters'].values():
+        new_variables = []
+        if 'variables' in parameter:
+            for key, value in parameter['variables'].items():
+                value['name'] = key
+                new_variables.append(value)
+        parameter['variables'] = new_variables
+
+    # Convert simulate in electrical_parameters
+    for parameter in datasheet['electrical_parameters'].values():
+        for key, value in parameter['simulate'].items():
+            value['tool'] = key
+
+            if 'format' in value:
+                new_format = []
+                new_format.append(value.pop('format'))
+                new_format.append(value.pop('suffix'))
+                new_format += value.pop('variables')
+
+                value['format'] = new_format
+
+        parameter['simulate'] = value
+
+    # Convert spec entries in electrical_parameters
+    for parameter in datasheet['electrical_parameters'].values():
+
+        if 'spec' in parameter:
+            for limit in ['minimum', 'typical', 'maximum']:
+                if limit in parameter['spec']:
+                    if 'fail' in parameter['spec'][limit]:
+                        new_limit = []
+                        new_limit.append(parameter['spec'][limit]['value'])
+
+                        if parameter['spec'][limit]['fail'] == True:
+                            new_limit.append('fail')
+                            if 'calculation' in parameter['spec'][limit]:
+                                new_limit.append(
+                                    parameter['spec'][limit]['calculation']
+                                )
+
+                        parameter['spec'][limit] = new_limit
+                    else:
+                        parameter['spec'][limit] = parameter['spec'][limit][
+                            'value'
+                        ]
+
+    # Convert evaluate in physical_parameters
+    for parameter in datasheet['physical_parameters'].values():
+
+        if isinstance(parameter['evaluate'], str):
+            value = {'tool': parameter['evaluate']}
         else:
-            arguments.append(item)
+            for key, value in parameter['evaluate'].items():
+                value['tool'] = key
 
-    debug = False
-    for item in options:
-        if item == '-debug':
-            debug = True
+                if 'script' in value:
+                    value['tool'] = [value['tool'], value.pop('script')]
 
-    result = 0
-    if len(arguments) == 1 and len(options) == 0:
-        filename = arguments[0]
+        parameter['evaluate'] = value
 
-        # If the file is a JSON file, read it with json.load
-        if os.path.splitext(filename)[1] == '.json':
-            if not os.path.isfile(filename):
-                print('Error:  No such file ' + filename)
-                result = 1
-            else:
-                with open(filename, 'r') as ifile:
-                    dataset = json.load(ifile)
-                    if dataset and 'data-sheet' in dataset:
-                        dataset = dataset['data-sheet']
-                        # Attempt to upgrade this to format 4.0
-                        dataset = cace_compat(dataset, debug)
-        else:
-            dataset = cace_read(filename, debug)
+    # Convert spec entries in physical_parameters
+    for parameter in datasheet['physical_parameters'].values():
 
-        if dataset == {}:
-            result = 1
-        else:
-            if debug:
-                print('Diagnostic---dataset is:')
-                print(str(dataset))
-            else:
-                print('CACE file has no syntax issues.')
+        if 'spec' in parameter:
+            for limit in ['minimum', 'typical', 'maximum']:
+                if limit in parameter['spec']:
+                    if 'fail' in parameter['spec'][limit]:
+                        new_limit = []
+                        new_limit.append(parameter['spec'][limit]['value'])
 
+                        if parameter['spec'][limit]['fail'] == True:
+                            new_limit.append('fail')
+                            if 'calculation' in parameter['spec'][limit]:
+                                new_limit.append(
+                                    parameter['spec'][limit]['calculation']
+                                )
+
+                        parameter['spec'][limit] = new_limit
+                    else:
+                        parameter['spec'][limit] = parameter['spec'][limit][
+                            'value'
+                        ]
+
+    # Convert default_conditions
+    new_datasheet['default_conditions'] = []
+    for key, value in datasheet['default_conditions'].items():
+        value['name'] = key
+        new_datasheet['default_conditions'].append(value)
+
+    # Convert electrical_parameters
+    new_datasheet['electrical_parameters'] = []
+    for key, value in datasheet['electrical_parameters'].items():
+        value['name'] = key
+        new_datasheet['electrical_parameters'].append(value)
+
+    # Convert physical_parameters
+    new_datasheet['physical_parameters'] = []
+    for key, value in datasheet['physical_parameters'].items():
+        value['name'] = key
+        new_datasheet['physical_parameters'].append(value)
+
+    # Convert dependencies TODO
+    if not new_datasheet['dependencies']:
+        new_datasheet['dependencies'] = []
+
+    if debug:
+        import pprint
+
+        pp = pprint.PrettyPrinter(depth=4)
+        pp.pprint(new_datasheet)
+
+    # TODO Remove runtime options from datasheet
+    # Set up runtime options in the dictionary before returning.
+
+    if 'runtime_options' in datasheet:
+        runtime_options = datasheet['runtime_options']
     else:
-        usage()
-        sys.exit(1)
+        runtime_options = {}
+    new_datasheet['runtime_options'] = runtime_options
 
-    sys.exit(result)
+    runtime_options['debug'] = debug
+    runtime_options['filename'] = filename
+
+    return new_datasheet

--- a/cace/common/cace_write.py
+++ b/cace/common/cace_write.py
@@ -23,7 +23,7 @@ import json
 import datetime
 import subprocess
 
-from .cace_regenerate import printwarn
+from .cace_regenerate import printwarn, get_pdk_root
 
 # ---------------------------------------------------------------
 # generate_svg

--- a/cace/common/cace_write.py
+++ b/cace/common/cace_write.py
@@ -23,7 +23,6 @@ import json
 import datetime
 import subprocess
 
-from .cace_compat import *
 from .cace_regenerate import printwarn
 
 # ---------------------------------------------------------------
@@ -1545,6 +1544,7 @@ def cace_output_known_dict(dictname, itemdict, outlines, doruntime, indent):
             'simulation',
             'plots',
             'logs',
+            'reports',
         ]
 
     elif dictname == 'dependencies':
@@ -1789,80 +1789,3 @@ def cace_write(datasheet, filename, doruntime=False):
         return 1
 
     return 0
-
-
-# ------------------------------------------------------------------
-# Print usage statement
-# ------------------------------------------------------------------
-
-
-def usage():
-    print('Usage:')
-    print('')
-    print('cace_write.py <filename> <outfilename>')
-    print('  Where <filename> is a pre-format 4.0 CACE JSON file.')
-    print('  and <outfilename> is the name for the output text file.')
-    print('  If <outfilename> ends in .html, then HTML is generated.')
-    print('')
-    print('When run from the top level, this program parses a CACE')
-    print('format JSON file and outputs a CACE format 4.0 text file.')
-
-
-# ------------------------------------------------------------------
-# If called from the command line, this can be used to read in a
-# pre-format 4.0 CACE JSON file and write out a CACE format 4.0
-# text file.  It does exactly the same thing as the cace_compat.py
-# script when run from the command line.
-# ------------------------------------------------------------------
-
-if __name__ == '__main__':
-    options = []
-    arguments = []
-    for item in sys.argv[1:]:
-        if item.find('-', 0) == 0:
-            options.append(item)
-        else:
-            arguments.append(item)
-
-    debug = False
-    for item in options:
-        if item == '-debug':
-            debug = True
-
-    result = 0
-
-    if len(arguments) == 2 and len(options) == 0:
-        infilename = arguments[0]
-        outfilename = arguments[1]
-        if not os.path.isfile(infilename):
-            print('Error:  No such file ' + infilename)
-            sys.exit(1)
-
-        with open(infilename, 'r') as ifile:
-            try:
-                dataset = json.load(ifile)
-            except json.decoder.JSONDecodeError as e:
-                print(
-                    'Error:  Parse error reading JSON file ' + datasheet + ':'
-                )
-                print(str(e))
-                sys.exit(1)
-
-        # If 'data-sheet' is a dictionary in 'dataset' then set that as the top
-        if 'data-sheet' in dataset:
-            dataset = dataset['data-sheet']
-        new_dataset = cace_compat(dataset, debug)
-        if debug:
-            print('Diagnostic (not writing file)---dataset is:')
-            print(str(new_dataset))
-        else:
-            if os.path.splitext(outfilename)[1] == '.html':
-                cace_generate_html(new_dataset, outfilename)
-            else:
-                result = cace_write(new_dataset, outfilename)
-
-    else:
-        usage()
-        sys.exit(1)
-
-    sys.exit(result)

--- a/cace/common/simulation_job.py
+++ b/cace/common/simulation_job.py
@@ -365,6 +365,8 @@ class SimulationJob(threading.Thread):
         # to the first entry.  This makes the simulation['format'] incorrect,
         # and other routines (like cace_makeplot) will need to adjust it.
 
+        print(simoutputfile)
+
         if os.path.isfile(simoutputfile):
             result = 1
             with open(simoutputfile, 'r') as ifile:

--- a/cace/common/simulation_manager.py
+++ b/cace/common/simulation_manager.py
@@ -16,12 +16,12 @@ import os
 import re
 import sys
 import time
+import yaml
 import shutil
 import signal
 import threading
 
 from .cace_read import cace_read
-from .cace_compat import cace_compat
 from .cace_write import (
     cace_write,
     cace_summary,
@@ -57,7 +57,6 @@ class SimulationManager:
             'force': False,
             'keep': False,
             'nosim': False,
-            'json': False,
             'sequential': False,  # TODO implement
             'noplot': False,  # TODO test
             'parallel_parameters': 4,
@@ -77,28 +76,12 @@ class SimulationManager:
 
         [dspath, dsname] = os.path.split(datasheet_path)
 
-        # Read the datasheet, legacy format
-        if os.path.splitext(datasheet_path)[1] == '.json':
-            with open(datasheet_path) as ifile:
-                try:
-                    # "data-sheet" as a sub-entry of the input file is deprecated.
-                    datatop = json.load(ifile)
-                    if 'data-sheet' in datatop:
-                        datatop = datatop['data-sheet']
-                except json.decoder.JSONDecodeError as e:
-                    print(
-                        'Error:  Parse error reading JSON file '
-                        + datasheet_path
-                        + ':'
-                    )
-                    print(str(e))
-                    return
-        # New format
+        # Read the datasheet, legacy CACE ASCII format version 4.0
+        if os.path.splitext(datasheet_path)[1] == '.txt':
+            self.datasheet = cace_read(datasheet_path, debug)
+        # Read the datasheet, new CACE YAML format version 5.0
         else:
-            datatop = cace_read(datasheet_path, debug)
-
-        # Ensure that datasheet complies with CACE version 4.0 format
-        self.datasheet = cace_compat(datatop, debug)
+            self.datasheet = cace_read_yaml(datasheet_path, debug)
 
         # CACE should be run from the location of the datasheet's root
         # directory.  Typically, the datasheet is in the "cace" subdirectory
@@ -107,7 +90,7 @@ class SimulationManager:
         rootpath = None
         paths = self.datasheet['paths']
         if 'root' in paths:
-            rootpath = self.datasheet['paths']['root']
+            rootpath = paths['root']
 
         if rootpath:
             dspath = os.path.join(dspath, rootpath)
@@ -119,6 +102,8 @@ class SimulationManager:
             print(
                 f'Working directory set to {dspath} ({os.path.abspath(dspath)})'
             )
+
+        print(self.datasheet)
 
         # set the filename
         self.datasheet['runtime_options']['filename'] = os.path.abspath(
@@ -139,6 +124,30 @@ class SimulationManager:
 
         dirname = os.path.split(search_dir)[1]
         dirlist = os.listdir(search_dir)
+
+        # Look through all directories for a '.yaml' file
+        for item in dirlist:
+            if os.path.isfile(item):
+                fileext = os.path.splitext(item)[1]
+                basename = os.path.splitext(item)[0]
+                if fileext == '.yaml':
+                    if basename == dirname:
+                        print(f'Loading datasheet from {item}')
+                        self.load_datasheet(item, debug)
+                        return 0
+
+            elif os.path.isdir(item):
+                subdirlist = os.listdir(item)
+                for subitem in subdirlist:
+                    subitemref = os.path.join(item, subitem)
+                    if os.path.isfile(subitemref):
+                        fileext = os.path.splitext(subitem)[1]
+                        basename = os.path.splitext(subitem)[0]
+                        if fileext == '.yaml':
+                            if basename == dirname:
+                                print(f'Loading datasheet from {subitemref}')
+                                self.load_datasheet(subitemref, debug)
+                                return 0
 
         # Look through all directories for a '.txt' file
         for item in dirlist:
@@ -196,14 +205,214 @@ class SimulationManager:
         if self.datasheet['runtime_options']['debug']:
             print(f'Writing final output file {path}')
 
-        if self.datasheet['runtime_options']['json']:
-            # Dump the result as a JSON file
-            jsonfile = os.path.splitext(path)[0] + '_debug.json'
-            with open(jsonfile, 'w') as ofile:
-                json.dump(self.datasheet, ofile, indent=4)
-        else:
-            # Write the result in CACE ASCII format version 4.0
+        suffix = os.path.splitext(path)[1]
+
+        if suffix == '.txt':
+            # Write the result in legacy CACE ASCII format version 4.0
             cace_write(self.datasheet, path, doruntime=False)
+        elif suffix == '.yaml':
+            # Write the result in CACE YAML format version 5.0
+            new_datasheet = self.datasheet.copy()
+
+            # Rewrite internal datasheet structure
+            # for format version 5.0 compatibility
+
+            # TODO Remove this step and change the remaining code
+            # in CACE to work with dictionaries
+
+            # Convert pins
+            new_datasheet['pins'] = {}
+            for pin in self.datasheet['pins']:
+                name = pin.pop('name')
+
+                if 'Vmax' in pin:
+                    if isinstance(pin['Vmax'], list):
+                        pin['Vmax'] = ' '.join(pin['Vmax'])
+
+                if 'Vmin' in pin:
+                    if isinstance(pin['Vmin'], list):
+                        pin['Vmin'] = ' '.join(pin['Vmin'])
+
+                new_datasheet['pins'][name] = pin
+
+            # Convert conditions in electrical_parameters
+            for parameter in self.datasheet['electrical_parameters']:
+                new_conditions = {}
+                for condition in parameter['conditions']:
+                    name = condition.pop('name')
+                    new_conditions[name] = condition
+                parameter['conditions'] = new_conditions
+
+            # Convert simulate in electrical_parameters
+            for parameter in self.datasheet['electrical_parameters']:
+                new_simulate = {}
+
+                tool = parameter['simulate'].pop('tool')
+
+                if 'format' in parameter['simulate']:
+                    format_list = parameter['simulate'].pop('format')
+
+                    parameter['simulate']['format'] = format_list[0]
+                    parameter['simulate']['suffix'] = format_list[1]
+                    parameter['simulate']['variables'] = format_list[2:]
+
+                parameter['simulate'] = {tool: parameter['simulate']}
+
+            # Convert variables in electrical_parameters
+            for parameter in self.datasheet['electrical_parameters']:
+                if 'variables' in parameter:
+                    new_variables = {}
+                    for variable in parameter['variables']:
+                        name = variable.pop('name')
+                        new_variables[name] = variable
+                    parameter['variables'] = new_variables
+
+            # Convert spec entries in electrical_parameters
+            for parameter in self.datasheet['electrical_parameters']:
+                if 'spec' in parameter:
+                    for limit in ['minimum', 'typical', 'maximum']:
+                        if limit in parameter['spec']:
+                            new_limit = {}
+                            if not isinstance(parameter['spec'][limit], list):
+                                try:
+                                    new_limit[
+                                        'value'
+                                    ] = f'{float(parameter["spec"][limit]):g}'
+                                except:
+                                    new_limit['value'] = parameter['spec'][
+                                        limit
+                                    ]
+                            elif len(parameter['spec'][limit]) == 2:
+                                try:
+                                    new_limit[
+                                        'value'
+                                    ] = f'{float(parameter["spec"][limit][0]):g}'
+                                except:
+                                    new_limit['value'] = parameter['spec'][
+                                        limit
+                                    ][0]
+                                new_limit['fail'] = True
+                            elif len(parameter['spec'][limit]) == 3:
+                                try:
+                                    new_limit[
+                                        'value'
+                                    ] = f'{float(parameter["spec"][limit][0]):g}'
+                                except:
+                                    new_limit['value'] = parameter['spec'][
+                                        limit
+                                    ][0]
+                                new_limit['fail'] = True
+                                new_limit['calculation'] = parameter['spec'][
+                                    limit
+                                ][2]
+
+                            parameter['spec'][limit] = new_limit
+
+            # Convert evaluate in physical_parameters
+            for parameter in self.datasheet['physical_parameters']:
+                tool = parameter['evaluate'].pop('tool')
+                new_evaluate = tool
+
+                if isinstance(tool, list):
+                    if tool[0] == 'cace_lvs':
+                        parameter['evaluate']['script'] = tool[1]
+                        tool = 'cace_lvs'
+                    else:
+                        print(f'Error: Unknown tool list {tool}')
+
+                if parameter['evaluate']:
+                    new_evaluate = {tool: parameter['evaluate']}
+                else:
+                    new_evaluate = tool
+
+                parameter['evaluate'] = new_evaluate
+
+            # Convert spec entries in physical_parameters
+            for parameter in self.datasheet['physical_parameters']:
+                if 'spec' in parameter:
+                    for limit in ['minimum', 'typical', 'maximum']:
+                        if limit in parameter['spec']:
+                            new_limit = {}
+                            if not isinstance(parameter['spec'][limit], list):
+                                try:
+                                    new_limit[
+                                        'value'
+                                    ] = f'{float(parameter["spec"][limit]):g}'
+                                except:
+                                    new_limit['value'] = parameter['spec'][
+                                        limit
+                                    ]
+                            elif len(parameter['spec'][limit]) == 2:
+                                try:
+                                    new_limit[
+                                        'value'
+                                    ] = f'{float(parameter["spec"][limit][0]):g}'
+                                except:
+                                    new_limit['value'] = parameter['spec'][
+                                        limit
+                                    ][0]
+                                new_limit['fail'] = True
+                            elif len(parameter['spec'][limit]) == 3:
+                                try:
+                                    new_limit[
+                                        'value'
+                                    ] = f'{float(parameter["spec"][limit][0]):g}'
+                                except:
+                                    new_limit['value'] = parameter['spec'][
+                                        limit
+                                    ][0]
+                                new_limit['fail'] = True
+                                new_limit['calculation'] = parameter['spec'][
+                                    limit
+                                ][2]
+
+                            parameter['spec'][limit] = new_limit
+
+            # Convert default_conditions
+            new_datasheet['default_conditions'] = {}
+            for default_condition in self.datasheet['default_conditions']:
+                name = default_condition.pop('name')
+                new_datasheet['default_conditions'][name] = default_condition
+
+            # Convert electrical_parameters
+            new_datasheet['electrical_parameters'] = {}
+            for electrical_parameter in self.datasheet[
+                'electrical_parameters'
+            ]:
+                name = electrical_parameter.pop('name')
+                new_datasheet['electrical_parameters'][
+                    name
+                ] = electrical_parameter
+
+            # Convert physical_parameters
+            new_datasheet['physical_parameters'] = {}
+            for physical_parameter in self.datasheet['physical_parameters']:
+                name = physical_parameter.pop('name')
+                new_datasheet['physical_parameters'][name] = physical_parameter
+
+            # Rewrite paths['root'] as the cwd relative to filename.
+            oldroot = None
+            if 'paths' in new_datasheet:
+                paths = new_datasheet['paths']
+                if 'root' in paths:
+                    oldroot = paths['root']
+                    filepath = os.path.split(path)[0]
+                    newroot = os.path.relpath(os.curdir, filepath)
+                    paths['root'] = newroot
+
+            # Remove runtime options
+            new_datasheet.pop('runtime_options')
+
+            with open(os.path.join(path), 'w') as outfile:
+                yaml.dump(
+                    new_datasheet,
+                    outfile,
+                    default_flow_style=False,
+                    sort_keys=False,
+                    allow_unicode=True,
+                )
+        else:
+            print(f'Unsupported file extension: {suffix}')
 
     def set_datasheet(self, datasheet):
         """Set a new datasheet"""

--- a/cace/gui/rowwidget.py
+++ b/cace/gui/rowwidget.py
@@ -296,9 +296,9 @@ class RowWidget:
                 if 'unit' in self.param and not binrex.match(
                     self.param['unit']
                 ):
-                    targettext = pmin + ' ' + self.param['unit']
+                    targettext = f'{pmin} {self.param["unit"]}'
                 else:
-                    targettext = pmin
+                    targettext = str(pmin)
                 min_limit = targettext
 
         return min_limit
@@ -378,9 +378,9 @@ class RowWidget:
                 if 'unit' in self.param and not binrex.match(
                     self.param['unit']
                 ):
-                    targettext = ptyp + ' ' + self.param['unit']
+                    targettext = f'{ptyp} {self.param["unit"]}'
                 else:
-                    targettext = ptyp
+                    targettext = str(ptyp)
                 typ_limit = targettext
 
         return typ_limit
@@ -460,9 +460,9 @@ class RowWidget:
                 if 'unit' in self.param and not binrex.match(
                     self.param['unit']
                 ):
-                    targettext = pmax + ' ' + self.param['unit']
+                    targettext = f'{pmax} {self.param["unit"]}'
                 else:
-                    targettext = pmax
+                    targettext = str(pmax)
                 max_limit = targettext
 
         return max_limit

--- a/cace/gui/settings.py
+++ b/cace/gui/settings.py
@@ -181,6 +181,10 @@ class Settings(tkinter.Toplevel):
         # return the state of the "edit all parameters" checkbox
         return False if self.doedit.get() == 0 else True
 
+    def set_debug(self, debug):
+        # set the state of the "print debug output" checkbox
+        self.dodebug.set(debug)
+
     def get_debug(self):
         # return the state of the "print debug output" checkbox
         return False if self.dodebug.get() == 0 else True


### PR DESCRIPTION
Make YAML the new default datasheet format, remove support for JSON format.

- When searching for the datasheet, `.yaml` is preferred over `.txt`.
- When saving a datasheet, `.yaml` is the default extension.

After loading a YAML datasheet the internal datastructure should be identical to the one loaded from a text file. Exception: In the "pins" section, Vmax and Vmin are now just a string instead of a list, e.g. `dvdd - 0.3`.