### PR TITLE
Add portability checks for paths

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,12 @@
+# 2.3.2
+
+## Common
+
+- Add portability checks for paths. Warn the user:
+     - If there are any paths containing `libs.tech`
+       or `libs.ref` that are not using `{PDK_ROOT}`
+     - If the path has the user's $HOME as a leading component
+
 # 2.3.1
 
 ## Common

--- a/cace/__version__.py
+++ b/cace/__version__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = '2.3.1'
+__version__ = '2.3.2'
 
 if __name__ == '__main__':
     print(__version__, end='')

--- a/cace/common/cace_gensim.py
+++ b/cace/common/cace_gensim.py
@@ -718,6 +718,34 @@ def substitute(
 
     simlines = simtext.replace('\n+', ' ').splitlines()
 
+    # Portability checks!
+    # Warn the user:
+    # - If there are any paths containing "libs.tech"
+    #   or "libs.ref" that are not using "{PDK_ROOT}"
+    # - If the path has the user's $HOME as a leading component
+
+    pathrex = re.compile(r'([\/]?(?:[^\s]+\/)+[^\s]+)')
+    for line in simlines:
+        paths = pathrex.findall(line)
+
+        for path in paths:
+            if (
+                'libs.tech' in path
+                or 'libs.ref' in path
+                and not '{PDK_ROOT}' in path
+            ):
+                print(f'Warning: This path may not be portable: {path}')
+                print(
+                    f'Reason: Contains "libs.tech" or "libs.ref" but {{PDK_ROOT}} is missing'
+                )
+
+            if (
+                path.startswith(os.path.expanduser('~'))
+                and not '** sch_path:' in line
+            ):
+                print(f'Warning: This path may not be portable: {path}')
+                print(f"Reason: Starts with the user's home directory")
+
     # Make initial pass over contents of template file, looking for conditions
     # with values (e.g., "Vdd|maximum").  These indicate that the condition is
     # not enumerated over testbenches, so collapse simvals accordingly.


### PR DESCRIPTION
For example, the following line: `.lib /home/leo/.volare/sky130A/libs.tech/combined/sky130.lib.spice {corner}`

Throws the following warnings:

```
Warning: This path may not be portable: /home/leo/.volare/sky130A/libs.tech/combined/sky130.lib.spice
Reason: Contains "libs.tech" or "libs.ref" but {PDK_ROOT} is missing
```

```
Warning: This path may not be portable: /home/leo/.volare/sky130A/libs.tech/combined/sky130.lib.spice
Reason: Starts with the user's home directory
```

At the moment the warnings get a little lost in all the output. That's why I want to work on reworking the messaging system next.

Fixes #71 