### PR TITLE
Improve netlist generation

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,10 @@
+# 2.3.5
+
+## Common
+
+- Improve netlist generation
+    * Schematic netlist is always generated to get the correct port order for the extracted netlists
+
 # 2.3.4
 
 ## Common

--- a/cace/__version__.py
+++ b/cace/__version__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = '2.3.4'
+__version__ = '2.3.5'
 
 if __name__ == '__main__':
     print(__version__, end='')

--- a/cace/cace_cli.py
+++ b/cace/cace_cli.py
@@ -112,7 +112,7 @@ def cli():
         '-s',
         '--source',
         type=str,
-        choices=['schematic', 'layout', 'rcx', 'all', 'best'],
+        choices=['schematic', 'layout', 'pex', 'rcx', 'best'],
         default='best',
         help="""choose the netlist source for characterization. By default, or when using \'best\', characterization is run on the full R-C
     parasitic extracted netlist if the layout is available, else on the schematic captured netlist.""",

--- a/cace/common/cace_makeplot.py
+++ b/cace/common/cace_makeplot.py
@@ -45,7 +45,7 @@ from ..logging import subprocess as subproc
 from ..logging import debug as dbg
 
 
-def cace_makeplot(dsheet, param, plotdir, parent=None):
+def cace_makeplot(dsheet, param, plotdir=None, parent=None):
     """
     Given a plot record from a spec sheet and a full set of testbenches, generate
     a plot.  The name of the plot file and the vectors to plot, labels, legends,
@@ -583,7 +583,7 @@ def cace_makeplot(dsheet, param, plotdir, parent=None):
     if legend:
         legend.set_draggable(True)
 
-    if parent == None:
+    if plotdir:
         paths = dsheet['paths']
         """if 'plots' in paths:
             plotdir = paths['plots']


### PR DESCRIPTION
Schematic netlist is always generated to get the correct port order for the extracted netlists