### PR TITLE
Do not generate testbench netlists in parallel

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+# 2.3.6
+
+## Common
+
+- Do not generate testbench netlists in parallel, this leads to race conditions
+
 # 2.3.5
 
 ## Common

--- a/cace/__version__.py
+++ b/cace/__version__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = '2.3.5'
+__version__ = '2.3.6'
 
 if __name__ == '__main__':
     print(__version__, end='')

--- a/cace/parameter/electrical_parameter.py
+++ b/cace/parameter/electrical_parameter.py
@@ -19,7 +19,6 @@ import threading
 from multiprocessing import cpu_count
 from multiprocessing.pool import ThreadPool
 
-from ..common.cace_regenerate import regenerate_testbenches
 from ..common.cace_gensim import *
 from ..common.cace_collate import *
 from ..common.cace_makeplot import *
@@ -174,18 +173,9 @@ class ElectricalParameter(Parameter):
     # this is a problem when a testbench is canceled
     def preprocess(self):
 
-        # Get the set of paths from the characterization file
-        paths = self.datasheet['paths']
+        dbg(f'Parameter {self.param["name"]}: Generating simulation files')
 
-        # Generate testbench netlists if needed
-        result = regenerate_testbenches(self.datasheet, self.param['name'])
-        if result == 1:
-            err(
-                f'Parameter {self.param["name"]}: Failed to regenerate testbench netlists'
-            )
-            return 1
-
-        dbg(f'Parameter {self.param["name"]}: Evaluating electrical parameter')
+        # Generate the spice netlists for simulation from the template
         cace_gensim(self.datasheet, self.param, self.param_dir)
 
         # Diagnostic:  find and print the number of files to be simulated
@@ -219,6 +209,9 @@ class ElectricalParameter(Parameter):
 
         alltestbenches = []
         results = []
+
+        # Create an empty testbench list to hold
+        # the testbenches that are returned
         self.new_testbenches = []
 
         for i in range(0, len(testbenches), group_size):
@@ -238,8 +231,7 @@ class ElectricalParameter(Parameter):
             )
             self.add_simulation_job(new_sim_job)
 
-            # Create an empty testbench list to hold
-            # the testbenches that are returned
+            # Append an empty testbench
             self.new_testbenches.append([None])
 
             idx += 1

--- a/cace/parameter/parameter_manager.py
+++ b/cace/parameter/parameter_manager.py
@@ -31,7 +31,10 @@ from ..common.cace_write import (
     markdown_summary,
     cace_generate_html,
 )
-from ..common.cace_regenerate import regenerate_netlists
+from ..common.cace_regenerate import (
+    regenerate_netlists,
+    regenerate_testbenches,
+)
 from .physical_parameter import PhysicalParameter
 from .electrical_parameter import ElectricalParameter
 
@@ -807,6 +810,17 @@ class ParameterManager:
             err('Failed to regenerate project netlist, aborting.')
             self.cancel_parameters(True)
             return
+
+        # Next, for each parameter generate testbench netlists if needed
+        for thread in self.queued_threads:
+            result = regenerate_testbenches(
+                self.datasheet, thread.param['name']
+            )
+            if result == 1:
+                err(
+                    f'Parameter {self.param["name"]}: Failed to regenerate testbench netlists'
+                )
+                return 1
 
         # Only start a new worker thread, if
         # the previous one hasn't completed yet


### PR DESCRIPTION
Do not generate testbench netlists in parallel, this leads to race conditions.