### PR TITLE
Implement `--jobs` argument

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,10 @@
+# 2.3.7
+
+## Common
+
+- Add support for the `-j`/`--jobs` flag to limit the maximum number of jobs running in parallel
+- Parallelized simulations with collated conditions (Monte Carlo for example)
+
 # 2.3.6
 
 ## Common

--- a/cace/__version__.py
+++ b/cace/__version__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = '2.3.6'
+__version__ = '2.3.7'
 
 if __name__ == '__main__':
     print(__version__, end='')

--- a/cace/cace_cli.py
+++ b/cace/cace_cli.py
@@ -108,6 +108,13 @@ def cli():
         help='output specification datasheet (YAML)',
     )
 
+    # total number of jobs, optional
+    parser.add_argument(
+        '-j',
+        '--jobs',
+        type=int,
+        help="""total number of jobs running in parallel""",
+    )
     parser.add_argument(
         '-s',
         '--source',
@@ -183,7 +190,7 @@ def cli():
         set_log_level(args.log_level)
 
     # Create the ParameterManager
-    parameter_manager = ParameterManager()
+    parameter_manager = ParameterManager(jobs=args.jobs)
 
     # Get the run dir
     run_dir = parameter_manager.run_dir

--- a/cace/cace_gui.py
+++ b/cace/cace_gui.py
@@ -93,10 +93,10 @@ class ConfirmDialog(Dialog):
 class CACEGui(ttk.Frame):
     """Main class for this application"""
 
-    def __init__(self, parent, *args, **kwargs):
+    def __init__(self, parent, jobs=None, *args, **kwargs):
         ttk.Frame.__init__(self, parent, *args, **kwargs)
         self.root = parent
-        self.parameter_manager = ParameterManager()
+        self.parameter_manager = ParameterManager(jobs=jobs)
         self.init_gui()
         parent.protocol('WM_DELETE_WINDOW', self.on_quit)
 
@@ -1151,6 +1151,14 @@ def gui():
         help='input specification datasheet (YAML)',
     )
 
+    # total number of jobs, optional
+    parser.add_argument(
+        '-j',
+        '--jobs',
+        type=int,
+        help="""total number of jobs running in parallel""",
+    )
+
     # on/off flag, optional
     parser.add_argument(
         '--terminal',
@@ -1183,7 +1191,7 @@ def gui():
 
     # Create tkinter root
     root = tkinter.Tk(className='CACE')
-    app = CACEGui(root)
+    app = CACEGui(root, args.jobs)
 
     # Enable debug output
     if args.debug:

--- a/cace/common/cace_makeplot.py
+++ b/cace/common/cace_makeplot.py
@@ -154,7 +154,7 @@ def cace_makeplot(dsheet, param, plotdir=None, parent=None):
         notfound = True
         for cond in conditions:
             if cond[0] == xname:
-                condvalue = cond[2]
+                condvalue = str(cond[2])
                 notfound = False
                 break
 
@@ -173,9 +173,9 @@ def cace_makeplot(dsheet, param, plotdir=None, parent=None):
             condstr = ''
             for cond in conditions:
                 if cond[0] == xname:
-                    condvalue = cond[2]
+                    condvalue = str(cond[2])
                 else:
-                    condstr += cond[2]
+                    condstr += str(cond[2])
             thistb['condstr'] = condstr
             newtbresults = []
             for result in tbresults:
@@ -370,7 +370,7 @@ def cace_makeplot(dsheet, param, plotdir=None, parent=None):
         slist = []
         for i in range(0, len(conditions)):
             if stepped[i] == True:
-                klist.append(conditions[i][2])
+                klist.append(str(conditions[i][2]))
                 slist.append(
                     conditions[i][0]
                     + '='

--- a/cace/parameter/parameter.py
+++ b/cace/parameter/parameter.py
@@ -47,6 +47,7 @@ class Parameter(ABC, Thread):
         paths,
         runtime_options,
         run_dir,
+        jobs_sem,
         start_cb=None,
         end_cb=None,
         cancel_cb=None,
@@ -60,6 +61,7 @@ class Parameter(ABC, Thread):
         self.paths = paths
         self.runtime_options = runtime_options
         self.run_dir = run_dir
+        self.jobs_sem = jobs_sem
         self.start_cb = start_cb
         self.end_cb = end_cb
         self.cancel_cb = cancel_cb

--- a/cace/parameter/parameter_manager.py
+++ b/cace/parameter/parameter_manager.py
@@ -58,7 +58,7 @@ class ParameterManager:
     manipulate it.
     """
 
-    def __init__(self, datasheet={}):
+    def __init__(self, datasheet={}, jobs=None):
         """Initialize the object with a datasheet"""
         self.datasheet = datasheet
 
@@ -90,6 +90,19 @@ class ParameterManager:
         }
 
         self.set_default_paths()
+
+        # Set the number of jobs to the number of cores
+        # if jobs=None
+        if not jobs:
+            jobs = os.cpu_count()
+
+        # Fallback jobs
+        if not jobs:
+            jobs = 4
+
+        self.jobs_sem = threading.Semaphore(value=jobs)
+
+        dbg(f'Parameter manager: total number of jobs is {jobs}')
 
         # Create a new run dir for logs
         self.prepare_run_dir()
@@ -651,6 +664,7 @@ class ParameterManager:
                         paths,
                         runtime_options,
                         self.run_dir,
+                        self.jobs_sem,
                         start_cb,
                         end_cb,
                         cancel_cb,
@@ -692,6 +706,7 @@ class ParameterManager:
                         paths,
                         runtime_options,
                         self.run_dir,
+                        self.jobs_sem,
                         start_cb,
                         end_cb,
                         cancel_cb,

--- a/cace/parameter/physical_parameter.py
+++ b/cace/parameter/physical_parameter.py
@@ -57,6 +57,7 @@ class PhysicalParameter(Parameter):
         paths,
         runtime_options,
         run_dir,
+        jobs_sem,
         start_cb=None,
         end_cb=None,
         cancel_cb=None,
@@ -71,6 +72,7 @@ class PhysicalParameter(Parameter):
             paths,
             runtime_options,
             run_dir,
+            jobs_sem,
             start_cb,
             end_cb,
             cancel_cb,
@@ -828,19 +830,30 @@ class PhysicalParameter(Parameter):
         else:
             toolargs = None
 
-        if tool == 'cace_area':
-            resultdict = self.cace_area(datasheet, param, 'area', toolargs)
-        elif tool == 'cace_width':
-            resultdict = self.cace_area(datasheet, param, 'width', toolargs)
-        elif tool == 'cace_height':
-            resultdict = self.cace_area(datasheet, param, 'height', toolargs)
-        elif tool == 'cace_drc':
-            resultdict = self.cace_drc(datasheet, param, toolargs)
-        elif tool == 'cace_lvs':
-            resultdict = self.cace_lvs(datasheet, param, toolargs)
-        else:
-            err('Unknown evaluation procedure ' + tool + ';  not evaluating.')
-            return param
+        # Acquire a job from the global jobs semaphore
+        with self.jobs_sem:
+
+            if tool == 'cace_area':
+                resultdict = self.cace_area(datasheet, param, 'area', toolargs)
+            elif tool == 'cace_width':
+                resultdict = self.cace_area(
+                    datasheet, param, 'width', toolargs
+                )
+            elif tool == 'cace_height':
+                resultdict = self.cace_area(
+                    datasheet, param, 'height', toolargs
+                )
+            elif tool == 'cace_drc':
+                resultdict = self.cace_drc(datasheet, param, toolargs)
+            elif tool == 'cace_lvs':
+                resultdict = self.cace_lvs(datasheet, param, toolargs)
+            else:
+                err(
+                    'Unknown evaluation procedure '
+                    + tool
+                    + ';  not evaluating.'
+                )
+                return param
 
         resultdict['name'] = runtime_options['netlist_source']
         addnewresult(param, resultdict)

--- a/docs/source/usage/cace_cli.md
+++ b/docs/source/usage/cace_cli.md
@@ -8,24 +8,10 @@ $ cace [<datasheet>] [<output>] [options]
 
 Where `<datasheet>` is an input specification in YAML (`*.yaml`) and `<output>` is an optional file path under which the output file is to be saved. If `<datasheet>` is not specified, CACE searches for a file with the same name as the current directory under `cace/` with the file extension `.yaml`.
 
-Options may be one of:
-
-```console
---source=schematic|layout|rcx|all|best
---param=<parameter_name> <parameter_name> ...
---force
---json
---keep
---debug
---sequential
---no-simulation
---summary
-```
-
-When run from the top level, this program parses the CACE characterization file, runs simulations for the specified parameters or all if none are given, and outputs a modified file annotated with characterization results.
+When run from the top level, this program parses the CACE characterization file, runs simulations for the specified parameters or all if none are given, and (optionally) outputs a modified file annotated with characterization results.
 
 The option `--source`, restricts characterization to the specific netlist source, which is either schematic capture,
-layout extracted, or full R-C parasitic extracted. If not specified, then characterization is run on the full R-C
+layout extracted, C parasitic extracted or full R-C parasitic extracted. If not specified, then characterization is run on the full R-C
 parasitic extracted layout netlist if available, and the schematic captured netlist if not (option "best").
 
 ```console
@@ -36,9 +22,10 @@ positional arguments:
 options:
   -h, --help            show this help message and exit
   --version             show program's version number and exit
-  -s {schematic,layout,rcx,all,best}, --source {schematic,layout,rcx,all,best}
-                        choose the netlist source for characterization. By default, or when using 'best', characterization is run on
-                        the full R-C parasitic extracted netlist if the layout is available, else on the schematic captured netlist.
+  -j JOBS, --jobs JOBS  total number of jobs running in parallel
+  -s {schematic,layout,pex,rcx,best}, --source {schematic,layout,pex,rcx,best}
+                        choose the netlist source for characterization. By default, or when using 'best', characterization is run on the full R-C parasitic
+                        extracted netlist if the layout is available, else on the schematic captured netlist.
   -p PARAMETER [PARAMETER ...], --parameter PARAMETER [PARAMETER ...]
                         run simulations on only the named parameters, by default run all parameters
   --parallel_parameters PARALLEL_PARAMETERS


### PR DESCRIPTION
This PR implements the `-j`/`--jobs` argument to limit the maximum number of jobs run in parallel.
By default the jobs are equal to the number of cores.