### PR TITLE
Add `--max-runs` argument and print total runtime

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,16 @@
+# 2.3.8
+
+## GUI
+
+- Added `--max-runs` to limit the maximum number of runs in the run folder
+
+## CLI
+
+- Print the total runtime after completion
+- Removed `--no-simulation` as the output files never exist in a new timestamp
+- Renamed `--parallel_parameters` to `--parallel-parameters`
+- Added `--max-runs` to limit the maximum number of runs in the run folder
+
 # 2.3.7
 
 ## Common

--- a/cace/__version__.py
+++ b/cace/__version__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = '2.3.7'
+__version__ = '2.3.8'
 
 if __name__ == '__main__':
     print(__version__, end='')

--- a/cace/cace_cli.py
+++ b/cace/cace_cli.py
@@ -153,7 +153,7 @@ def cli():
     # total number of jobs, optional
     parser.add_argument(
         '--max-runs',
-        type=lambda value : int(value) if int(value) > 0 else 1,
+        type=lambda value: int(value) if int(value) > 0 else 1,
         help="""the maximum number of runs to keep in the "runs/" folder, the oldest runs will be deleted""",
     )
     parser.add_argument(
@@ -198,7 +198,9 @@ def cli():
         set_log_level(args.log_level)
 
     # Create the ParameterManager
-    parameter_manager = ParameterManager(max_runs=args.max_runs, jobs=args.jobs)
+    parameter_manager = ParameterManager(
+        max_runs=args.max_runs, jobs=args.jobs
+    )
 
     # Get the run dir
     run_dir = parameter_manager.run_dir
@@ -319,7 +321,7 @@ def cli():
     progress.stop()
 
     # Get the runtime and print it
-    delta = str(timedelta(seconds=time.time() - timestamp_start)).split(".")[0]
+    delta = str(timedelta(seconds=time.time() - timestamp_start)).split('.')[0]
     info(f'Done with CACE simulations and evaluations in {delta}.')
 
     # Print the summary to the console

--- a/cace/cace_gui.py
+++ b/cace/cace_gui.py
@@ -93,10 +93,10 @@ class ConfirmDialog(Dialog):
 class CACEGui(ttk.Frame):
     """Main class for this application"""
 
-    def __init__(self, parent, jobs=None, *args, **kwargs):
+    def __init__(self, parent, max_runs=None, jobs=None, *args, **kwargs):
         ttk.Frame.__init__(self, parent, *args, **kwargs)
         self.root = parent
-        self.parameter_manager = ParameterManager(jobs=jobs)
+        self.parameter_manager = ParameterManager(max_runs=max_runs, jobs=jobs)
         self.init_gui()
         parent.protocol('WM_DELETE_WINDOW', self.on_quit)
 
@@ -1159,6 +1159,12 @@ def gui():
         help="""total number of jobs running in parallel""",
     )
 
+    parser.add_argument(
+        '--max-runs',
+        type=lambda value : int(value) if int(value) > 0 else 1,
+        help="""the maximum number of runs to keep in the "runs/" folder, the oldest runs will be deleted""",
+    )
+
     # on/off flag, optional
     parser.add_argument(
         '--terminal',
@@ -1191,7 +1197,7 @@ def gui():
 
     # Create tkinter root
     root = tkinter.Tk(className='CACE')
-    app = CACEGui(root, args.jobs)
+    app = CACEGui(root, args.max_runs, args.jobs)
 
     # Enable debug output
     if args.debug:

--- a/cace/cace_gui.py
+++ b/cace/cace_gui.py
@@ -1161,7 +1161,7 @@ def gui():
 
     parser.add_argument(
         '--max-runs',
-        type=lambda value : int(value) if int(value) > 0 else 1,
+        type=lambda value: int(value) if int(value) > 0 else 1,
         help="""the maximum number of runs to keep in the "runs/" folder, the oldest runs will be deleted""",
     )
 

--- a/cace/parameter/parameter_manager.py
+++ b/cace/parameter/parameter_manager.py
@@ -58,9 +58,10 @@ class ParameterManager:
     manipulate it.
     """
 
-    def __init__(self, datasheet={}, jobs=None):
+    def __init__(self, datasheet={}, max_runs=None, jobs=None):
         """Initialize the object with a datasheet"""
         self.datasheet = datasheet
+        self.max_runs = max_runs
 
         self.worker_thread = None
 
@@ -804,9 +805,11 @@ class ParameterManager:
         info(f"Starting a new run with the tag '{tag}'.")
         mkdirp(self.run_dir)
 
-        # TODO make configurable
-        if len(runs) >= 5:
-            remove = runs[:-4]
+        # Delete the oldest runs if max_runs set TODO only works for >=2
+        if self.max_runs and len(runs) >= self.max_runs:
+            runs = runs[::-1] # Reverse runs
+            # Select runs to remove
+            remove = runs[self.max_runs-1:]
             dbg(f'Removing run directories: {remove}')
 
             for run in remove:

--- a/cace/parameter/parameter_manager.py
+++ b/cace/parameter/parameter_manager.py
@@ -807,9 +807,9 @@ class ParameterManager:
 
         # Delete the oldest runs if max_runs set TODO only works for >=2
         if self.max_runs and len(runs) >= self.max_runs:
-            runs = runs[::-1] # Reverse runs
+            runs = runs[::-1]   # Reverse runs
             # Select runs to remove
-            remove = runs[self.max_runs-1:]
+            remove = runs[self.max_runs - 1 :]
             dbg(f'Removing run directories: {remove}')
 
             for run in remove:

--- a/docs/source/usage/cace_cli.md
+++ b/docs/source/usage/cace_cli.md
@@ -24,20 +24,20 @@ options:
   --version             show program's version number and exit
   -j JOBS, --jobs JOBS  total number of jobs running in parallel
   -s {schematic,layout,pex,rcx,best}, --source {schematic,layout,pex,rcx,best}
-                        choose the netlist source for characterization. By default, or when using 'best', characterization is run on the full R-C parasitic
-                        extracted netlist if the layout is available, else on the schematic captured netlist.
+                        choose the netlist source for characterization. By default, or when using 'best', characterization is run on the full R-C parasitic extracted netlist if the layout is available, else on the schematic
+                        captured netlist.
   -p PARAMETER [PARAMETER ...], --parameter PARAMETER [PARAMETER ...]
                         run simulations on only the named parameters, by default run all parameters
-  --parallel_parameters PARALLEL_PARAMETERS
+  --parallel-parameters PARALLEL_PARAMETERS
                         the maximum number of parameters running in parallel
   -f, --force           force new regeneration of all netlists
   -k, --keep            retain files generated for characterization
+  --max-runs MAX_RUNS   the maximum number of runs to keep in the "runs/" folder, the oldest runs will be deleted
   --no-plot             do not generate any graphs
   --debug               generate additional diagnostic output
   -l {ALL,DEBUG,INFO,WARNING,ERROR}, --log-level {ALL,DEBUG,INFO,WARNING,ERROR}
                         set the log level for a more fine-grained output
   --sequential          runs simulations sequentially
-  --no-simulation       do not re-run simulations if the output file exists. (Warning: Does not check if simulations are out of date)
   --no-progress-bar     do not display the progress bar
 ```
 


### PR DESCRIPTION
- Added `--max-runs` to both the CLI and GUI to limit the maximum number of runs in the run folder
- Print the total runtime after completion of the CLI run