### PR TITLE
Substitution Improvement

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+# 2.4.2
+
+## Common
+
+- Do not perform substitutions if the conditions is not defined.
+
 # 2.4.1
 
 ## CLI

--- a/cace/__version__.py
+++ b/cace/__version__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = '2.4.1'
+__version__ = '2.4.2'
 
 if __name__ == '__main__':
     print(__version__, end='')

--- a/cace/common/cace_write.py
+++ b/cace/common/cace_write.py
@@ -211,7 +211,7 @@ def generate_documentation(datasheet):
         layout_path = os.path.join(layout_directory, layoutname)
         # Search for compressed layout
         if not os.path.exists(layout_path):
-            layoutname = projname + '.gds.gz'
+            layoutname = datasheet['name'] + '.gds.gz'
             layout_path = os.path.join(layout_directory, layoutname)
     else:
         err('No "layout" specified in datasheet paths.')
@@ -244,7 +244,7 @@ def generate_documentation(datasheet):
         layout_path = os.path.join(layout_directory, layoutname)
         # Search for compressed layout
         if not os.path.exists(layout_path):
-            layoutname = projname + '.gds.gz'
+            layoutname = datasheet['name'] + '.gds.gz'
             layout_path = os.path.join(layout_directory, layoutname)
     else:
         err('Neither "magic" nor "layout" specified in datasheet paths.')

--- a/cace/parameter/parameter.py
+++ b/cace/parameter/parameter.py
@@ -671,6 +671,11 @@ class Parameter(ABC, Thread):
 
             # Check whether the condition is in the set
             if cond_name in conditions_set:
+
+                # Condition not defined
+                if conditions_set[cond_name] == None:
+                    return matchobj.group(0)
+
                 # Simply replace with the full value
                 if not indices:
                     replace = str(conditions_set[cond_name])
@@ -718,7 +723,9 @@ class Parameter(ABC, Thread):
                 return replace
             else:
                 err(f'Could not find {cond_name} in condition set.')
-            return ''
+
+            # Error, do not change the condition value
+            return matchobj.group(0)
 
         def sweepex_sub(matchobj):
             cond_name = matchobj.group(1)

--- a/cace/parameter/parameter_ngspice.py
+++ b/cace/parameter/parameter_ngspice.py
@@ -323,7 +323,7 @@ class ParameterNgspice(Parameter):
                     # have a value
                     for cond in condition_set:
                         if condition_set[cond] == None:
-                            err(f'Condition {cond} not defined')
+                            warn(f'Condition {cond} not defined')
 
                     # Write conditions set
                     with open(


### PR DESCRIPTION
If a conditions does not exist, do not replace the placeholder. For example, if the xschem template contains `\{ib\}` and `ib` is not a condition in CACE, leave it as is.