### PR TITLE
Use absolute path for layout

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+# 2.4.8
+
+## Common
+
+- Use absolute path for layout
+
 # 2.4.7
 
 ## Common

--- a/cace/__version__.py
+++ b/cace/__version__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = '2.4.7'
+__version__ = '2.4.8'
 
 if __name__ == '__main__':
     print(__version__, end='')

--- a/cace/parameter/parameter_magic_area.py
+++ b/cace/parameter/parameter_magic_area.py
@@ -113,7 +113,7 @@ class ParameterMagicArea(Parameter):
                 magic_input += f'path search +{os.path.abspath(os.path.dirname(layout_filepath))}\n'
                 magic_input += f'load {os.path.basename(layout_filepath)}\n'
             else:
-                magic_input += f'gds read {layout_filepath}\n'
+                magic_input += f'gds read {os.path.abspath(layout_filepath)}\n'
                 magic_input += 'set toplist [cellname list top]\n'
                 magic_input += 'set numtop [llength $toplist]\n'
                 magic_input += 'if {$numtop > 1} {\n'

--- a/cace/parameter/parameter_magic_drc.py
+++ b/cace/parameter/parameter_magic_drc.py
@@ -102,7 +102,7 @@ class ParameterMagicDRC(Parameter):
             else:
                 if self.get_argument('gds_flatten'):
                     magic_input += 'gds flatglob *\n'
-                magic_input += f'gds read {layout_filepath}\n'
+                magic_input += f'gds read {os.path.abspath(layout_filepath)}\n'
                 magic_input += 'set toplist [cellname list top]\n'
                 magic_input += 'set numtop [llength $toplist]\n'
                 magic_input += 'if {$numtop > 1} {\n'


### PR DESCRIPTION
Use absolute path to access the layout as the parameters are started from the `run/` directory.