### PR TITLE
Improve layout regeneration

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,12 @@
+# 2.4.11
+
+## Common
+
+- Improve netlist regeneration:
+  - Call `extract no all` when netlist source is layout
+  - Use correct layout image names when GDS is compressed
+  - Don't crash when GDS layout is not found
+
 # 2.4.10
 
 ## Common

--- a/cace/__version__.py
+++ b/cace/__version__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = '2.4.10'
+__version__ = '2.4.11'
 
 if __name__ == '__main__':
     print(__version__, end='')

--- a/cace/common/cace_regenerate.py
+++ b/cace/common/cace_regenerate.py
@@ -292,6 +292,10 @@ def regenerate_netlist(datasheet, netlist_source, runtime_options, pex=False):
         dname, paths, check_magic='magic' in paths
     )
 
+    if layout_filepath == None:
+        err(f'No layout for project {dname} found.')
+        return False
+
     # Schematic-captured netlist
     if 'netlist' in paths:
         schem_netlist_path = os.path.join(paths['netlist'], 'schematic')
@@ -315,7 +319,7 @@ def regenerate_netlist(datasheet, netlist_source, runtime_options, pex=False):
 
     if need_extract:
         if layout_filepath == None:
-            err(f'Error: No layout for project {dname} found.')
+            err(f'No layout for project {dname} found.')
             return False
 
         # Check for netlist directory
@@ -360,9 +364,11 @@ def regenerate_netlist(datasheet, netlist_source, runtime_options, pex=False):
             magic_input += f'load {dname}\n'
 
         if netlist_source == 'layout' or netlist_source == 'pex':
-            magic_input += f'select {dname}\n'
+            magic_input += f'select top cell\n'
             magic_input += 'expand\n'
             magic_input += 'extract path cace_extfiles\n'
+            if netlist_source == 'layout':
+                magic_input += 'extract no all\n'
             magic_input += 'extract all\n'
             magic_input += 'ext2spice lvs\n'
             if netlist_source == 'pex':
@@ -372,7 +378,7 @@ def regenerate_netlist(datasheet, netlist_source, runtime_options, pex=False):
             )
 
         if netlist_source == 'rcx':
-            magic_input += f'select {dname}\n'
+            magic_input += f'select top cell\n'
             magic_input += 'expand\n'
             magic_input += f'flatten {dname + "_flat"}\n'
             magic_input += f'load {dname + "_flat"}\n'

--- a/cace/common/cace_write.py
+++ b/cace/common/cace_write.py
@@ -25,6 +25,7 @@ from .common import (
     xschem_generate_svg,
     magic_generate_svg,
     klayout_generate_png,
+    get_layout_path,
 )
 from .spiceunits import spice_unit_convert, spice_unit_unconvert
 from ..parameter.parameter import ResultType
@@ -207,46 +208,20 @@ def generate_documentation(datasheet):
 
     # Use GDSII
     if 'layout' in datasheet['paths']:
-        layout_directory = datasheet['paths']['layout']
-        layoutname = datasheet['name'] + '.gds'
-        layout_path = os.path.join(layout_directory, layoutname)
-        # Search for compressed layout
-        if not os.path.exists(layout_path):
-            layoutname = datasheet['name'] + '.gds.gz'
-            layout_path = os.path.join(layout_directory, layoutname)
 
+        # Get the path to the GDSII layout
+        (layout_filepath, is_magic) = get_layout_path(
+            datasheet['name'], datasheet['paths'], False
+        )
+
+        # Generate KLayout image
         klayout_generate_png(
-            layout_path,
+            layout_filepath,
             os.path.join(
                 datasheet['paths']['root'], datasheet['paths']['documentation']
             ),
+            datasheet['name'],
         )
-
-    # Generate magic image
-
-    svgpath = os.path.join(
-        datasheet['paths']['root'],
-        datasheet['paths']['documentation'],
-        f'{datasheet["name"]}_magic.svg',
-    )
-
-    # Prefer magic layout
-    if 'magic' in datasheet['paths']:
-        magic_directory = datasheet['paths']['magic']
-        magicname = datasheet['name'] + '.mag'
-        layout_path = os.path.join(magic_directory, magicname)
-        is_mag = True
-    # Else use GDSII
-    elif 'layout' in datasheet['paths']:
-        layout_directory = datasheet['paths']['layout']
-        layoutname = datasheet['name'] + '.gds'
-        layout_path = os.path.join(layout_directory, layoutname)
-        # Search for compressed layout
-        if not os.path.exists(layout_path):
-            layoutname = datasheet['name'] + '.gds.gz'
-            layout_path = os.path.join(layout_directory, layoutname)
-
-    # magic_generate_svg(layout_path, svgpath)
 
 
 def markdown_summary(datasheet, runtime_options, results, result_types):

--- a/cace/common/common.py
+++ b/cace/common/common.py
@@ -147,7 +147,7 @@ def get_layout_path(projname, paths, check_magic=False):
 
     err('Neither magic nor (compressed) GDS layout found.')
 
-    return (None, None, None)
+    return (None, None)
 
 
 def get_klayout_techfile():
@@ -398,21 +398,23 @@ def magic_generate_svg(layout_path, svgpath):
     return 0
 
 
-def klayout_generate_png(layout_path, out_path):
+def klayout_generate_png(layout_filepath, out_path, out_name):
     """
     Generate a PNG drawing of a layout using klayout
 
     Return 0 if the drawing was generated, 1 if not.
     """
 
-    if not os.path.isfile(layout_path):
-        err(f'Could not find {layout_path}.')
+    if layout_filepath == None:
+        err(f'No layout found.')
         return 1
 
-    layout_directory = os.path.split(layout_path)[0]
-    layout_filename = os.path.split(layout_path)[1]
-    layout_cellname = os.path.splitext(layout_filename)[0]
-    layout_extension = os.path.splitext(layout_filename)[1]
+    if not os.path.isfile(layout_filepath):
+        err(f'Could not find {layout_filepath}.')
+        return 1
+
+    layout_directory = os.path.dirname(layout_filepath)
+    layout_filename = os.path.basename(layout_filepath)
 
     techfile = get_klayout_techfile()
     layer_props = get_klayout_layer_props()
@@ -485,11 +487,11 @@ lv.save_image_with_options(os.path.join(out_path, out_name + "_b.png"), w, h, 0,
             '-r',
             scriptpath,
             '-rd',
-            f'gds_path={layout_path}',
+            f'gds_path={layout_filepath}',
             '-rd',
             f'out_path={out_path}',
             '-rd',
-            f'out_name={layout_cellname}',
+            f'out_name={out_name}',
             '-rd',
             f'tech_name={tech_name}',
             '-rd',

--- a/cace/parameter/parameter_manager.py
+++ b/cace/parameter/parameter_manager.py
@@ -283,8 +283,6 @@ class ParameterManager:
                 ofile.write(summary)
 
                 # Save the plots
-
-                # TODO
                 ofile.write(f'\n## Plots\n')
 
                 for parameter in self.datasheet['parameters']:


### PR DESCRIPTION
- Improve netlist regeneration:
  - Call `extract no all` when netlist source is layout
  - Use correct layout image names when GDS is compressed
  - Don't crash when GDS layout is not found