### PR TITLE
Implement `magic_antenna_check` tool

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+# 2.4.12
+
+- Add `magic_antenna_check` as a tool
+  - Performs antenna violation checks using magic
+  - Returns `antenna_violations`, the number of violations that have occured
+
 # 2.4.11
 
 ## Common

--- a/cace/__version__.py
+++ b/cace/__version__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = '2.4.11'
+__version__ = '2.4.12'
 
 if __name__ == '__main__':
     print(__version__, end='')

--- a/cace/parameter/__init__.py
+++ b/cace/parameter/__init__.py
@@ -17,5 +17,6 @@ from .parameter_manager import ParameterManager
 from .parameter_netgen_lvs import ParameterNetgenLVS
 from .parameter_magic_drc import ParameterMagicDRC
 from .parameter_magic_area import ParameterMagicArea
+from .parameter_magic_antenna_check import ParameterMagicAntennaCheck
 from .parameter_ngspice import ParameterNgspice
 from .parameter_klayout_drc import ParameterKLayoutDRC

--- a/cace/parameter/parameter_magic_drc.py
+++ b/cace/parameter/parameter_magic_drc.py
@@ -163,5 +163,10 @@ class ParameterMagicDRC(Parameter):
                 if lmatch:
                     drccount = int(lmatch.group(1))
 
-        self.result_type = ResultType.SUCCESS
-        self.get_result('drc_errors').values = [drccount]
+        if drccount != None:
+            self.result_type = ResultType.SUCCESS
+            self.get_result('drc_errors').values = [drccount]
+
+        # Increment progress bar
+        if self.step_cb:
+            self.step_cb(self.param)

--- a/docs/source/reference_manual/tools.md
+++ b/docs/source/reference_manual/tools.md
@@ -43,6 +43,18 @@ Results:
 - `width`: `<float>` Width of the design in µm.
 - `height`: `<float>` Height of the design in µm.
 
+## `magic_antenna_check`
+
+Perform the magic antenna check to find antenna violations in the layout.
+
+Arguments:
+
+- `args`: `<list[string]>` Additional args that are passed to magic.
+
+Results:
+
+- `antenna_violations`: `<int>` The number of antenna violations.
+
 ## `klayout_drc`
 
 Perform DRC (Design Rule Check) with KLayout.


### PR DESCRIPTION
- Add `magic_antenna_check` as a tool
  - Performs antenna violation checks using magic
  - Returns `antenna_violations`, the number of violations that have occured

Example datasheet entry:

```yaml
  magic_antenna_check:
    description: Run antenna violation check using magic
    display: Antenna Checks
    spec:
      antenna_violations:
        maximum:
          value: 0
    tool:
        magic_antenna_check
```