### PR TITLE
Add `runs` path to datasheet

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,18 @@
+# 2.4.13
+
+## Common
+
+- Add `runs` path to datasheet
+  - Specifies where the `runs` directory will be created
+
+## CLI
+
+- Add `--run-path` to arguments
+  - Overrides `runs` path from datasheet
+
 # 2.4.12
+
+## Common
 
 - Add `magic_antenna_check` as a tool
   - Performs antenna violation checks using magic

--- a/cace/__version__.py
+++ b/cace/__version__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = '2.4.12'
+__version__ = '2.4.13'
 
 if __name__ == '__main__':
     print(__version__, end='')

--- a/cace/cace_cli.py
+++ b/cace/cace_cli.py
@@ -159,6 +159,11 @@ def cli():
         help="""the maximum number of runs to keep in the "runs/" folder, the oldest runs will be deleted""",
     )
     parser.add_argument(
+        '--run-path',
+        type=str,
+        help='override the default "runs/" directory',
+    )
+    parser.add_argument(
         '--no-plot', action='store_true', help='do not generate any graphs'
     )
     parser.add_argument(
@@ -194,7 +199,7 @@ def cli():
 
     # Create the ParameterManager
     parameter_manager = ParameterManager(
-        max_runs=args.max_runs, jobs=args.jobs
+        max_runs=args.max_runs, run_path=args.run_path, jobs=args.jobs
     )
 
     # Load the datasheet

--- a/cace/parameter/parameter_manager.py
+++ b/cace/parameter/parameter_manager.py
@@ -61,10 +61,11 @@ class ParameterManager:
     manipulate it.
     """
 
-    def __init__(self, datasheet={}, max_runs=None, jobs=None):
+    def __init__(self, datasheet={}, max_runs=None, run_path=None, jobs=None):
         """Initialize the object with a datasheet"""
         self.datasheet = datasheet
         self.max_runs = max_runs
+        self.run_path = run_path
 
         self.worker_thread = None
 
@@ -93,6 +94,7 @@ class ParameterManager:
         self.default_paths = {
             'templates': 'cace/templates',
             'scripts': 'cace/scripts',
+            'runs': 'runs',
         }
 
         self.set_default_paths()
@@ -604,13 +606,19 @@ class ParameterManager:
             .strftime('RUN_%Y-%m-%d_%H-%M-%S')
         )
 
+        run_path = self.datasheet['paths']['runs']
+
+        # Override runs dir with cli argument
+        if self.run_path:
+            run_path = self.run_path
+
         # Create new run dir
         self.run_dir = os.path.abspath(
-            os.path.join(self.design_dir, 'runs', tag)
+            os.path.join(self.design_dir, run_path, tag)
         )
 
         # Check if run dir already exists
-        runs = sorted(glob.glob(os.path.join(self.design_dir, 'runs', '*')))
+        runs = sorted(glob.glob(os.path.join(self.design_dir, run_path, '*')))
 
         if self.run_dir in runs:
             error('Run directory exists already. Please try again.')

--- a/docs/source/reference_manual/datasheet_format.md
+++ b/docs/source/reference_manual/datasheet_format.md
@@ -101,6 +101,9 @@ paths:
 - `documentation: <path>`
     > Location for the auto-generated documentation of the design.
 
+- `runs: <path>` (optional)
+	> Location for the run directory.
+
 ## Pins
 
 The pins of the design, mainly used for documentation purposes. The names of the pins are checked against the schematic.

--- a/docs/source/usage/cace_cli.md
+++ b/docs/source/usage/cace_cli.md
@@ -37,6 +37,7 @@ options:
                         the maximum number of parameters running in parallel
   -f, --force           force new regeneration of all netlists
   --max-runs MAX_RUNS   the maximum number of runs to keep in the "runs/"
+  --run-path RUN_PATH   override the default "runs/" directory
                         folder, the oldest runs will be deleted
   --no-plot             do not generate any graphs
   -l {ALL,DEBUG,INFO,WARNING,ERROR}, --log-level {ALL,DEBUG,INFO,WARNING,ERROR}


### PR DESCRIPTION
## Common

- Add `runs` path to datasheet
  - Specifies where the `runs` directory will be created

## CLI

- Add `--run-path` to arguments
  - Overrides `runs` path from datasheet

Example datasheet entry:

```yaml
paths:
  root:             ..
  schematic:        xschem
  layout:           gds
  netlist:          netlist
  documentation:    docs
  runs:             _runs
```


Fixes #110 
Should be merged after #112 