### PR TITLE
Implement plot limits

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,10 @@
+# 2.4.14
+
+## Common
+
+- Implement plot limits
+  - Plots have an optional argument `limits`, which can be `true`, `false` or `auto`
+
 # 2.4.13
 
 ## Common

--- a/cace/__version__.py
+++ b/cace/__version__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = '2.4.13'
+__version__ = '2.4.14'
 
 if __name__ == '__main__':
     print(__version__, end='')

--- a/docs/source/reference_manual/datasheet_format.md
+++ b/docs/source/reference_manual/datasheet_format.md
@@ -441,20 +441,27 @@ Example entry:
         yaxis: [Vout, Vinp]
 ```
 
-- `type: <string>`
-	The type of plot to make. If this record is missing from the
+- `type: <string>` (optional)
+	> The type of plot to make. If this record is missing from the
 	dictionary, then plot type "xyplot" is assumed by default.
 	Otherwise, the value should be one of "xyplot", "histogram",
 	"semilogx", "semilogy", or "loglog".
 
 - `xaxis: <name>`
-	Variable to be plotted on the graph X axis.
+	> Variable to be plotted on the graph X axis.
 
 - `yaxis: <name>|<list[name]>`
-	Variable to be plotted on the graph Y axis.
+	> Variables to be plotted on the graph Y axis.
 
-- `title: <string>`
-	A title for the graph.
+- `title: <string>` (optional)
+	> A title for the graph.
+
+- `limits: <false|true|auto>` (optional)
+  - `false` - do not show limits
+  - `true` - always show limits
+  - `auto` - show limits if they are in the yrange
+
+    The default setting for `limits` is auto.
 
 Plots are made from measured columnar data which may be from a "wrdata"
 command in ngspice or an "echo" statement directed to a file.


### PR DESCRIPTION
- Implement plot limits
  - Plots have an optional argument `limits`, which can be `true`, `false` or `auto`

Example entry:

```yaml
    plot:
      gain_vs_temp:
        type: xyplot
        xaxis: temperature
        yaxis: a0
        limits: true
      ugf_vs_corner:
        type: xyplot
        xaxis: corner
        yaxis: ugf
        limits: false
      pm_vs_vdd:
        type: xyplot
        xaxis: vdd
        yaxis: pm
        limits: auto
```

Fixes #111 