### PR TITLE
Preprocess datasheet with jinja

### DIFF
--- a/cace/parameter/parameter_manager.py
+++ b/cace/parameter/parameter_manager.py
@@ -125,13 +125,16 @@ class ParameterManager:
             err(f'File {datasheet_path} not found.')
             return 1
 
+        # Create a new run dir
+        self.prepare_run_dir()
+
         [dspath, dsname] = os.path.split(datasheet_path)
 
         suffix = os.path.splitext(datasheet_path)[1]
 
         if suffix == '.yaml':
             # Read the datasheet, new CACE YAML format version 5.0
-            self.datasheet = cace_read_yaml(datasheet_path)
+            self.datasheet = cace_read_yaml(datasheet_path, self.run_dir)
         elif suffix == '.txt':
             self.datasheet = cace_read(datasheet_path)
         else:
@@ -172,9 +175,6 @@ class ParameterManager:
 
         # Make sure all paths exist
         self.set_default_paths()
-
-        # Create a new run dir for logs
-        self.prepare_run_dir()
 
         return 0
 

--- a/default.nix
+++ b/default.nix
@@ -34,6 +34,7 @@
   tkinter,
   rich,
   gdsfactory,
+  jinja2
 }: let
 
   klayout-gdsfactory = klayout.withPythonPackages (ps:
@@ -87,6 +88,7 @@
         volare
         tkinter
         rich
+        jinja2
       ]
       ++ self.includedTools;
       

--- a/docs/source/reference_manual/datasheet_format.md
+++ b/docs/source/reference_manual/datasheet_format.md
@@ -6,6 +6,10 @@ Prior to June 2024 CACE used the datasheet version 4.0 text format. This format 
 
 The CACE datasheet contains the specification of your design and other important information. It acts as both documentation for the specifiaction but also as input for CACE. 
 
+```{note}
+The datasheet is preprocessed using [Jinja](https://jinja.palletsprojects.com/en/3.1.x/).
+```
+
 The following sections describe the structure of the datasheet.
 
 ## Metadata

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ numpy>=1.20.0
 pillow>=10.1.0
 volare>=0.16.0
 rich>=13,<14
+jinja2>=3.1.0


### PR DESCRIPTION
Use [Jinja](https://jinja.palletsprojects.com/en/3.1.x/) to preprocess the datasheet. This makes it possible to include other files from within the datasheet.

`datasheet.yaml`:

```yaml
...
    plot:
      gain_mc:
        type: histogram
        xaxis: a0
        limits: auto
    conditions:
{% include 'conditions.yaml' %}
```

`conditions.yaml`:

```yaml
      iterations:
        description: Iterations to run
        display: Iterations
        minimum: 1
        maximum: 10
        step: linear
        stepsize: 1
      corner:
        typical: mc
      temperature:
        minimum: -40
        typical: 27
        maximum: 130
```