### PR TITLE
Add runs summary as Markdown table

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+# 2.5.3
+
+## Common
+
+- Add a simulation summary for the `ngspice` tool
+
 # 2.5.2
 
 ## Common

--- a/cace/__version__.py
+++ b/cace/__version__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = '2.5.2'
+__version__ = '2.5.3'
 
 if __name__ == '__main__':
     print(__version__, end='')

--- a/cace/parameter/parameter_ngspice.py
+++ b/cace/parameter/parameter_ngspice.py
@@ -44,7 +44,9 @@ from ..logging import (
     success,
     warn,
     err,
+    console,
 )
+from rich.markdown import Markdown
 
 
 @register_parameter('ngspice')
@@ -743,6 +745,33 @@ class ParameterNgspice(Parameter):
         if self.get_argument('collate'):
             conditions[collate_variable] = collate_condition
 
+        # Extend simulation variables with script variables
+        variables.extend(script_variables)
+
+        # Create the simulation summary
+        simulation_summary = self.create_simulation_summary(
+            conditions,
+            condition_sets,
+            variables,
+            simulation_values,
+        )
+
+        # Get path for the simulation summary
+        outpath_sim_summary = os.path.join(
+            self.param_dir, f'simulation_summary.md'
+        )
+
+        # Save the simulation summary
+        with open(outpath_sim_summary, 'w') as f:
+            f.write(simulation_summary)
+
+        info(
+            f'Parameter {self.param["name"]}: Saving simulation summary as \'[repr.filename][link=file://{os.path.abspath(outpath_sim_summary)}]{os.path.relpath(outpath_sim_summary)}[/link][/repr.filename]\'…'
+        )
+
+        # Print the simulation summary in the console
+        console.print(Markdown(simulation_summary))
+
         # Create a plot if specified
         if 'plot' in self.param:
             # Create the plots and save them
@@ -754,6 +783,129 @@ class ParameterNgspice(Parameter):
                     simulation_values,
                     collate_variable,
                 )
+
+    def create_simulation_summary(
+        self,
+        conditions,
+        condition_sets,
+        variables,
+        simulation_values,
+    ):
+        """
+        Create a summary for all simulation runs in Markdown
+        """
+
+        summary_table = f'# Simulation Summary for {self.param["display"]}\n\n'
+
+        # Find all conditions with more than one value,
+        # these change between simulations
+        conditions_in_summary = []
+        for condition in conditions.values():
+            if len(condition.values) > 1:
+                conditions_in_summary.append(condition.name)
+
+        # Print the header
+        header_entries = []
+        header_separators = []
+
+        # First entry is the simulation run
+        header_entries.append('run')
+        header_separators.append(':--')
+
+        for cond in conditions_in_summary:
+            header_entries.append(str(cond))
+            header_separators.append('-' * max(len(str(cond)) - 1, 1) + ':')
+
+        # Get resulting variables (check for None)
+        for variable in variables:
+            if variable != None:
+                header_entries.append(str(variable))
+                header_separators.append(
+                    '-' * max(len(str(variable)) - 1, 1) + ':'
+                )
+
+        # Add header and separators
+        summary_table += f'| {" | ".join(header_entries)} |\n'
+        summary_table += f'| {" | ".join(header_separators)} |\n'
+
+        # Generate the entries
+        max_digits = len(str(len(condition_sets)))
+        max_entries_list = 3
+        for index, (condition_set, sim_values) in enumerate(
+            zip(condition_sets, simulation_values)
+        ):
+            body_entries = []
+            body_entries.append(f'run_{index:0{max_digits}d}')
+
+            for cond in conditions_in_summary:
+                if isinstance(condition_set[cond], list):
+                    if len(condition_set[cond]) == 1:
+                        body_entries.append(
+                            self.decimal2readable(condition_set[cond][0])
+                        )
+                        continue
+
+                    values = condition_set[cond][
+                        0 : min(max_entries_list, len(condition_set[cond]))
+                    ]
+                    values = [self.decimal2readable(value) for value in values]
+                    if len(condition_set[cond]) > max_entries_list:
+                        values.append('…')
+                    body_entries.append(f'[{", ".join(values)}]')
+                else:
+                    body_entries.append(
+                        self.decimal2readable(condition_set[cond])
+                    )
+
+            for variable in variables:
+                if variable != None:
+                    if isinstance(simulation_values[index][variable], list):
+                        if len(simulation_values[index][variable]) == 1:
+                            body_entries.append(
+                                self.decimal2readable(
+                                    simulation_values[index][variable][0]
+                                )
+                            )
+                            continue
+
+                        values = simulation_values[index][variable][
+                            0 : min(
+                                max_entries_list,
+                                len(simulation_values[index][variable]),
+                            )
+                        ]
+                        values = [
+                            self.decimal2readable(value) for value in values
+                        ]
+                        if (
+                            len(simulation_values[index][variable])
+                            > max_entries_list
+                        ):
+                            values.append('…')
+                        body_entries.append(f'[{", ".join(values)}]')
+                    else:
+                        body_entries.append(
+                            self.decimal2readable(
+                                simulation_values[index][variable]
+                            )
+                        )
+
+            summary_table += f'| {" | ".join(body_entries)} |\n'
+
+        return summary_table
+
+    def decimal2readable(self, decimal):
+        if isinstance(decimal, str):
+            return decimal
+
+        # Print zero as float
+        if decimal == 0:
+            return f'{decimal:.3f}'
+
+        if decimal < 0.1 or decimal > 100000:
+            return f'{decimal:.3e}'
+        else:
+            return f'{decimal:.3f}'
 
     def get_num_steps(self):
         return self.num_sims


### PR DESCRIPTION
This PR creates a summary for the simulation runs of a parameter using the `ngspice` tool.
CACE saves the summary as `simulation_summary.md` in the parameter directory and prints a rendered version.
The first column contains the run number, the following columns contain the changing conditions, and the last columns contain the results, which may look as follows:

```
  run        b   corner   temperature    vout   offset_error  
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 
  run_00    25       ss           -40   0.334      3.693e-03  
  run_01   230       ss           -40   3.299          0.101  
  run_02    25       tt           -40   0.335      3.749e-03  
  run_03   230       tt           -40   3.300          0.102  
  run_04    25       ff           -40   0.335      3.809e-03  
  run_05   230       ff           -40   3.300          0.102  
  run_06    25       ss            27   0.334      3.545e-03  
  run_07   230       ss            27   3.092      3.865e-02  
  run_08    25       tt            27   0.334      3.597e-03  
  run_09   230       tt            27   3.028      1.918e-02  
  run_10    25       ff            27   0.334      3.651e-03  
  run_11   230       ff            27   3.020      1.658e-02  
  run_12    25       ss           110   0.333      3.325e-03  
  run_13   230       ss           110   3.009      1.339e-02  
  run_14    25       tt           110   0.333      3.380e-03  
  run_15   230       tt           110   3.007      1.287e-02  
  run_16    25       ff           110   0.334      3.485e-03  
  run_17   230       ff           110   3.003      1.165e-02
```

Implements part of #122.

Future work: add a column indicating whether a single value passed or failed the spec (✅/❌). This requires CACE to check each result individually instead of forming a max/min over the range of values.