### PR TITLE
Queue and skip parameters via pattern matching

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,12 @@
+# 2.5.1
+
+## CLI
+
+- Allow parameters to be specified via `--parameter` as a pattern
+- Add `--skip-parameter` to skip certain parameters
+  - Applied after parameters have been queued via `--parameter`
+  - Also allows the use of patterns
+
 # 2.5.0
 
 ## Common

--- a/cace/__version__.py
+++ b/cace/__version__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = '2.5.0'
+__version__ = '2.5.1'
 
 if __name__ == '__main__':
     print(__version__, end='')


### PR DESCRIPTION
## CLI

- Allow parameters to be specified via `--parameter` as a pattern
- Add `--skip-parameter` to skip certain parameters
  - Applied after parameters have been queued via `--parameter`
  - Also allows the use of patterns

[fnmatch](https://docs.python.org/3/library/fnmatch.html) is used for pattern matching.

Resolves #125

### Example usage:

- To run all parameters starting with `klayout` run: `cace -p klayout*`
- To run all parameters except those starting with `klayout` run: `cace -sp klayout*`
- To run all parameters starting with `klayout` except `klayout_drc_full` run: `cace -p klayout* -sp klayout_drc_full`