### PR TITLE
Add `jobs` argument to inform CACE about number of jobs needed

### DIFF
--- a/cace/common/custom_semaphore.py
+++ b/cace/common/custom_semaphore.py
@@ -1,0 +1,41 @@
+from threading import Thread
+from threading import Condition
+
+from copy import copy
+
+
+class CustomSemaphore:
+    def __init__(self, value: int = 1):
+        if value < 0:
+            raise ValueError('Initial value must be >= 0')
+
+        # initialize counter
+        self._counter = value
+
+        # initialize lock
+        self._condition = Condition()
+
+    def __enter__(self):
+        self.acquire()
+
+    def __exit__(self, type, value, traceback):
+        self.release()
+
+    def acquire(self, count: int = 1) -> None:
+        """Acquire count permits atomically, or wait until they are available."""
+
+        with self._condition:
+            self._condition.wait_for(lambda: self._counter >= count)
+            self._counter -= count
+
+    def locked(self, count: int = 1) -> bool:
+        """Return True if acquire(count) would not return immediately."""
+
+        return self._counter < count
+
+    def release(self, count: int = 1) -> None:
+        """Release count permits."""
+
+        with self._condition:
+            self._counter += count
+            self._condition.notify_all()

--- a/cace/parameter/parameter_manager.py
+++ b/cace/parameter/parameter_manager.py
@@ -23,6 +23,8 @@ import signal
 import datetime
 import threading
 
+from ..common.custom_semaphore import CustomSemaphore
+
 from ..common.misc import mkdirp
 from ..common.cace_read import cace_read, cace_read_yaml
 from ..common.cace_write import (
@@ -104,11 +106,9 @@ class ParameterManager:
         if not jobs:
             jobs = os.cpu_count()
 
-        # Fallback jobs
-        if not jobs:
-            jobs = 4
-
-        self.jobs_sem = threading.Semaphore(value=jobs)
+        self.jobs_sem = CustomSemaphore(
+            value=jobs
+        )   # threading.Semaphore(value=jobs)
 
         dbg(f'Parameter manager: total number of jobs is {jobs}')
 

--- a/cace/parameter/parameter_ngspice.py
+++ b/cace/parameter/parameter_ngspice.py
@@ -65,7 +65,9 @@ class ParameterNgspice(Parameter):
             **kwargs,
         )
 
-        self.add_argument(Argument('template', None, True))   # TODO typing
+        # TODO implement typing for the arguments
+        self.add_argument(Argument('jobs', 1, False))
+        self.add_argument(Argument('template', None, True))
         self.add_argument(Argument('collate', None, False))
         self.add_argument(Argument('format', None, False))
         self.add_argument(Argument('suffix', None, False))
@@ -171,6 +173,19 @@ class ParameterNgspice(Parameter):
         for variable in script_variables:
             if variable != None:
                 self.add_result(Result(variable))
+
+        jobs = self.get_argument('jobs')
+
+        if jobs == 'max':
+            # Set the number of jobs to the number of cores
+            jobs = os.cpu_count()
+
+            # Fallback jobs
+            if not jobs:
+                jobs = 4
+        else:
+            # Make sure that jobs don't exceed max jobs
+            jobs = min(jobs, os.cpu_count())
 
         template = self.get_argument('template')
         template_path = os.path.join(self.paths['templates'], template)
@@ -329,14 +344,13 @@ class ParameterNgspice(Parameter):
                         'simpath': os.path.abspath(outpath),
                         'DUT_name': self.datasheet['name'],
                         'netlist_source': source,
+                        'jobs': jobs,  # TODO self.param['jobs'],
                         'N': index,
                         'DUT_path': os.path.abspath(dutpath),
                         'PDK_ROOT': get_pdk_root(),
                         'PDK': get_pdk(),
                         'include_DUT': os.path.abspath(dutpath),
-                        'random': str(
-                            int(time.time() * 1000) & 0x7FFFFFFF
-                        ),  # TODO
+                        'random': str(int(time.time() * 1000) & 0x7FFFFFFF),
                     }
 
                     # Set the reserved conditions
@@ -477,7 +491,7 @@ class ParameterNgspice(Parameter):
             err(f'Unsupported file extension for template: {template}')
 
         # Run all simulations
-        jobs = []
+        running_jobs = []
 
         info(f'Parameter {self.param["name"]}: Running simulations…')
 
@@ -554,24 +568,27 @@ class ParameterNgspice(Parameter):
                             outpath,
                             os.path.splitext(template)[0] + '.spice',
                             self.jobs_sem,
+                            jobs,
                             self.step_cb,
                         )
                         self.add_simulation_job(new_sim_job)
 
-                        jobs.append(pool.apply_async(new_sim_job.run, ()))
+                        running_jobs.append(
+                            pool.apply_async(new_sim_job.run, ())
+                        )
 
                 # Wait for completion
                 while 1:
                     self.cancel_point()
 
                     # Check if all tasks have completed
-                    if all([job.ready() for job in jobs]):
+                    if all([job.ready() for job in running_jobs]):
                         break
 
                     time.sleep(0.1)
 
                 # Get the results
-                for job in jobs:
+                for job in running_jobs:
                     if job.get() != 0:
                         self.result_type = ResultType.ERROR
                         return
@@ -1041,6 +1058,7 @@ class SimulationJob(threading.Thread):
         outpath,
         simfile,
         jobs_sem,
+        jobs,
         step_cb,
         *args,
         **kwargs,
@@ -1049,6 +1067,7 @@ class SimulationJob(threading.Thread):
         self.outpath = outpath
         self.simfile = simfile
         self.jobs_sem = jobs_sem
+        self.jobs = jobs
         self.step_cb = step_cb
 
         self.canceled = False
@@ -1131,22 +1150,28 @@ class SimulationJob(threading.Thread):
     def run(self):
         self.cancel_point()
 
-        # Acquire a job from the global jobs semaphore
-        with self.jobs_sem:
-            self.cancel_point()
+        # Acquire job(s) from the global jobs semaphore
+        self.jobs_sem.acquire(self.jobs)
 
-            # Run ngspice
-            returncode = self.run_subprocess(
-                'ngspice', ['--batch', self.simfile], cwd=self.outpath
-            )
+        self.cancel_point()
 
-            self.cancel_point()
+        # Run ngspice
+        returncode = self.run_subprocess(
+            'ngspice',
+            ['--batch', '--no-spiceinit', self.simfile],
+            cwd=self.outpath,
+        )
 
-            self._return = returncode
+        self.cancel_point()
 
-            # Call the step cb -> advance progress bar
-            if self.step_cb:
-                self.step_cb(self.param)
+        self._return = returncode
+
+        # Call the step cb -> advance progress bar
+        if self.step_cb:
+            self.step_cb(self.param)
+
+        # Free job(s) from the global jobs semaphore
+        self.jobs_sem.release(self.jobs)
 
         # For when the join function is called
         return self._return


### PR DESCRIPTION
This PR adds the `jobs` argument to inform CACE about number of jobs needed to run a certain tool.
This is necessary to prevent too many parameters being spawned that require more hardware threads than are available.
The `jobs` argument is implemented for the `ngspice` and `klayout_drc` tool.

TODO:

- Update documentation
- Add `CACE{jobs}` to get the total number of jobs allocated for the parameter inside the template